### PR TITLE
adds in support to evaluate variables in dynamic blocks

### DIFF
--- a/internal/app/tfsec/parser/block.go
+++ b/internal/app/tfsec/parser/block.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"github.com/zclconf/go-cty/cty"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -133,8 +134,15 @@ func (block *Block) parseDynamicBlockResult(dynamic *hclsyntax.Block) Blocks {
 	}
 
 	values := forEach.Value().AsValueSlice()
-	for range values {
+	for _, value := range values {
 		clone := *contentBlock
+		mapVal := map[string]cty.Value {
+			"value": value,
+		}
+		clone.ctx = &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+		}
+		clone.ctx.Variables[dynamic.Labels[0]] = cty.MapVal(mapVal)
 		results = append(results, &clone)
 	}
 

--- a/internal/app/tfsec/test/aws070_test.go
+++ b/internal/app/tfsec/test/aws070_test.go
@@ -49,6 +49,22 @@ resource "aws_elasticsearch_domain" "example" {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
     log_type                 = "AUDIT_LOGS"
   }
+`,
+			mustExcludeResultCode: checks.AWSESDomainLoggingEnabled,
+		},
+		{
+			name: "check passes if one of the log_type is AUDIT_LOGS and audit log is enabled - using dynamic block",
+			source: `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+	dynamic "log_publishing_options" {
+	  for_each = ["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS", "AUDIT_LOGS", "ES_APPLICATION_LOGS"]
+	  content {
+		enabled = true
+		cloudwatch_log_group_arn = aws_cloudwatch_log_group.es.arn
+		log_type = log_publishing_options.value
+	  }
+	}
 }
 `,
 			mustExcludeResultCode: checks.AWSESDomainLoggingEnabled,


### PR DESCRIPTION
### This change will support variables evaluation in `dynamic` blocks.
Example
```
resource "aws_elasticsearch_domain" "es" {
    dynamic "log_publishing_options" {
      for_each = ["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS", "AUDIT_LOGS", "ES_APPLICATION_LOGS"]
      content {
        enabled = true
        cloudwatch_log_group_arn = aws_cloudwatch_log_group.es.arn
        log_type = log_publishing_options.value
      }
    }
    
    // ....
```
Before this change `log_publishing_options.value` wouldn't` be evaluated and `AUDIT_LOGS` would never be found thus triggering `AWS070` rule.