### PR TITLE
Keep the check for rule AWS021 consistent with the error message

### DIFF
--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -74,24 +74,24 @@ func init() {
 			minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version")
 
 			minBaseVersion, minCipherSupportVersion, minVersionErr := func() (string, int, error) {
-        errorMessage := "Undecipherable minimum_protocol_version"
-        if minVersion.Type() != cty.String {
-          return "", 0, errors.New(errorMessage)
-        }
+				errorMessage := "Undecipherable minimum_protocol_version"
+				if minVersion.Type() != cty.String {
+					return "", 0, errors.New(errorMessage)
+				}
 
-        semver := strings.Split(minVersion.Value().AsString(), "_")
+				semver := strings.Split(minVersion.Value().AsString(), "_")
 
-        if len(semver) < 2 {
-          return "", 0, errors.New(errorMessage)
-        }
+				if len(semver) < 2 {
+					return "", 0, errors.New(errorMessage)
+				}
 
-        semverCipherSupportVersion, err := strconv.Atoi(semver[1])
+				semverCipherSupportVersion, err := strconv.Atoi(semver[1])
 
-        if err != nil {
-          return "", 0, err
-        }
+				if err != nil {
+					return "", 0, err
+				}
 
-        return semver[0], semverCipherSupportVersion, nil
+				return semver[0], semverCipherSupportVersion, nil
 			}()
 
 			if viewerCertificateBlock == nil {

--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -74,20 +74,24 @@ func init() {
 			minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version")
 
 			minBaseVersion, minCipherSupportVersion, minVersionErr := func() (string, int, error) {
-				if minVersion.Type() == cty.String {
-					semver := strings.Split(minVersion.Value().AsString(), "_")
-					if len(semver) > 1 {
-						semverCipherSupportVersion, err := strconv.Atoi(semver[1])
+        errorMessage := "Undecipherable minimum_protocol_version"
+        if minVersion.Type() != cty.String {
+          return "", 0, errors.New(errorMessage)
+        }
 
-						if err == nil {
-							return semver[0], semverCipherSupportVersion, nil
-						} else {
-							return "", 0, err
-						}
-					}
-				}
+        semver := strings.Split(minVersion.Value().AsString(), "_")
 
-				return "", 0, errors.New("Undecipherable minimum_protocol_version")
+        if len(semver) < 2 {
+          return "", 0, errors.New(errorMessage)
+        }
+
+        semverCipherSupportVersion, err := strconv.Atoi(semver[1])
+
+        if err != nil {
+          return "", 0, err
+        }
+
+        return semver[0], semverCipherSupportVersion, nil
 			}()
 
 			if viewerCertificateBlock == nil {

--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -3,7 +3,14 @@ package rules
 import (
 	"fmt"
 
+	"strings"
+
+	"strconv"
+
+	"errors"
+
 	"github.com/tfsec/tfsec/pkg/result"
+
 	"github.com/tfsec/tfsec/pkg/severity"
 
 	"github.com/tfsec/tfsec/pkg/provider"
@@ -64,6 +71,25 @@ func init() {
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			viewerCertificateBlock := resourceBlock.GetBlock("viewer_certificate")
+			minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version")
+
+			minBaseVersion, minCipherSupportVersion, minVersionErr := func() (string, int, error) {
+				if minVersion.Type() == cty.String {
+					semver := strings.Split(minVersion.Value().AsString(), "_")
+					if len(semver) > 1 {
+						semverCipherSupportVersion, err := strconv.Atoi(semver[1])
+
+						if err == nil {
+							return semver[0], semverCipherSupportVersion, nil
+						} else {
+							return "", 0, err
+						}
+					}
+				}
+
+				return "", 0, errors.New("Undecipherable minimum_protocol_version")
+			}()
+
 			if viewerCertificateBlock == nil {
 				set.Add(
 					result.New(resourceBlock).
@@ -73,14 +99,14 @@ func init() {
 				)
 			}
 
-			if minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version"); minVersion == nil {
+			if minVersion == nil {
 				set.Add(
 					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing minimum_protocol_version attribute)", resourceBlock.FullName())).
 						WithRange(viewerCertificateBlock.Range()).
 						WithSeverity(severity.Error),
 				)
-			} else if minVersion.Type() == cty.String && minVersion.Value().AsString() != "TLSv1.2_2021" {
+			} else if (minVersionErr != nil) || !(minBaseVersion == "TLSv1.2" && minCipherSupportVersion >= 2021) {
 				set.Add(
 					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2021)", resourceBlock.FullName())).

--- a/internal/app/tfsec/test/aws021_test.go
+++ b/internal/app/tfsec/test/aws021_test.go
@@ -42,6 +42,28 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }`,
 			mustIncludeResultCode: rules.AWSCloudFrontOutdatedProtocol,
 		},
+		{
+			name: "check TLS versions equal to 2021 are allowed",
+			source: `
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  viewer_certificate {
+    cloudfront_default_certificate = true
+	minimum_protocol_version = "TLSv1.2_2021"
+  }
+}`,
+			mustExcludeResultCode: rules.AWSCloudFrontOutdatedProtocol,
+		},
+		{
+			name: "check TLS versions greater than 2021 are allowed",
+			source: `
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  viewer_certificate {
+    cloudfront_default_certificate = true
+	minimum_protocol_version = "TLSv1.2_2024"
+  }
+}`,
+			mustExcludeResultCode: rules.AWSCloudFrontOutdatedProtocol,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The error message for AWS021 says -
"You should not use outdated/insecure TLS versions for
encryption. You should be using TLS v1.2+."

The rule is now consistent with this version and will not
complain if you afix a version higher than what tfsec prescribes.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers