### PR TITLE
handle null evalContext

### DIFF
--- a/internal/app/tfsec/block/hclblock.go
+++ b/internal/app/tfsec/block/hclblock.go
@@ -26,7 +26,13 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *hcl.EvalContext, moduleBlock Block) B
 }
 
 func (block *HCLBlock) Clone(index int) Block {
-	childCtx := block.evalContext.Parent().NewChild()
+	var childCtx *hcl.EvalContext
+	if block.evalContext != nil {
+		childCtx = block.evalContext.NewChild()
+	} else {
+		childCtx = &hcl.EvalContext{}
+	}
+
 	if childCtx.Variables == nil {
 		childCtx.Variables = make(map[string]cty.Value)
 	}


### PR DESCRIPTION
if there is no evalcontext for the block, create a new one

Resolves #882 