### PR TITLE
fix install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-env GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-X github.com/tfsec/tfsec/version.Version=${1}" ./cmd/tfsec
+env GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-X github.com/aquasecurity/tfsec/version.Version=${1}" ./cmd/tfsec


### PR DESCRIPTION
install.sh is used by homebrew to build the binary on the fly. fix the reference for setting the version