### PR TITLE
Print warning to stderr

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -202,7 +202,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if len(tfvarsPaths) == 0 && unusedTfvarsPresent(dir) {
-			_ = tml.Printf("\n<yellow>Warning: A tfvars file was found but not automatically used. \nDid you mean to specify the --tfvars-file flag?</yellow>\n")
+			fmt.Fprintf(os.Stderr, "Warning: A tfvars file was found but not automatically used. Did you mean to specify the --tfvars-file flag?\n")
 		}
 
 		debug.Log("Starting parser...")


### PR DESCRIPTION
the warning when a tfvars file is found but not used is causing issues
with the github action. Print the error to std.err

Resolves #aquasecurity/tfsec-pr-commenter-action/issues/11