### PR TITLE
Support both code and legacy code for config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,8 @@
 {
   "version": "0.2.0",
   "configurations": [
+
+
     {
       "name": "Basic tfsec",
       "type": "go",
@@ -39,6 +41,14 @@
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/tfsec/main.go",
       "args": ["${workspaceFolder}/example/foreach-module/src"]
+    },
+    {
+      "name": "config override test",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/tfsec/main.go",
+      "args": ["${workspaceFolder}/example/with_config_overrides"]
     },
     {
       "name": "workspace test",

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -413,7 +413,7 @@ func updateResultSeverity(results []result.Result) []result.Result {
 	var overriddenResults []result.Result
 	for _, res := range results {
 		for code, sev := range overrides {
-			if res.RuleID == code {
+			if res.RuleID == code || res.LegacyRuleID == code {
 				res.WithSeverity(severity.Severity(sev))
 			}
 		}

--- a/example/with_config_overrides/.tfsec/config.yml
+++ b/example/with_config_overrides/.tfsec/config.yml
@@ -1,0 +1,4 @@
+---
+severity_overrides:
+  AWS077: CRITICAL
+  aws-s3-specify-public-access-block: CRITICAL

--- a/example/with_config_overrides/main.tf
+++ b/example/with_config_overrides/main.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "for_web" {
+  bucket = "${local.prefix}-${lookup(each.value, "name")}-web"
+  acl    = "private"
+
+  tags = {
+    Name = "${local.prefix}-${lookup(each.value, "name")}-web"
+  }
+}


### PR DESCRIPTION
Severity overrides should support both new code and legacy code in addition to the severity values

Resolves #966
