### PR TITLE
feat: Allow `token_type` as a safe attribute

### DIFF
--- a/internal/app/tfsec/security/sensitive.go
+++ b/internal/app/tfsec/security/sensitive.go
@@ -21,6 +21,7 @@ var sensitiveAttributes = map[string]string{}
 var StringScanner = squealer.NewStringScanner()
 
 var whitelistTokens = []string{
+	"token_type",
 	"version",
 }
 


### PR DESCRIPTION
It is used in all the `vault_..._backend_role` resources and being a type, is safe.

E.g. https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend#token_type