### PR TITLE
Fix issue with documentdb instance kms id

### DIFF
--- a/internal/app/tfsec/rules/aws/documentdb/enable_storage_encryption_rule.go
+++ b/internal/app/tfsec/rules/aws/documentdb/enable_storage_encryption_rule.go
@@ -57,7 +57,6 @@ resource "aws_docdb_cluster" "good_example" {
 		},
 		RequiredLabels: []string{
 			"aws_docdb_cluster",
-			"aws_docdb_cluster_instance",
 		},
 		DefaultSeverity: severity.High,
 		CheckFunc: func(set result.Set, resourceBlock block.Block, _ block.Module) {


### PR DESCRIPTION
docdb instance doesn't support the kms id attribute.

Resolves #1019
