### PR TITLE
Update README to fix Docker Hub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are a number of Docker options available
 | Image Name | Base | Comment |
 |------------|------|---------|
 |[tfsec/tfsec](https://hub.docker.com/r/aquasec/tfsec)|alpine|Normal tfsec image|
-|[tfsec/tfsec-alpine](https://hub.docker.com/r/tfsec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
+|[tfsec/tfsec-alpine](https://hub.docker.com/r/aquasec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
 |[tfsec/tfsec-ci](https://hub.docker.com/r/tfsec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
 |[tfsec/tfsec-scratch](https://hub.docker.com/r/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ There are a number of Docker options available
 
 | Image Name | Base | Comment |
 |------------|------|---------|
-|[tfsec/tfsec](https://hub.docker.com/repository/docker/tfsec/tfsec)|alpine|Normal tfsec image|
-|[tfsec/tfsec-alpine](https://hub.docker.com/repository/docker/tfsec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
-|[tfsec/tfsec-ci](https://hub.docker.com/repository/docker/tfsec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
-|[tfsec/tfsec-scratch](https://hub.docker.com/repository/docker/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
+|[tfsec/tfsec](https://hub.docker.com/r/tfsec/tfsec)|alpine|Normal tfsec image|
+|[tfsec/tfsec-alpine](https://hub.docker.com/r/tfsec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
+|[tfsec/tfsec-ci](https://hub.docker.com/r/tfsec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
+|[tfsec/tfsec-scratch](https://hub.docker.com/r/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
 
 To run:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There are a number of Docker options available
 |[tfsec/tfsec](https://hub.docker.com/r/aquasec/tfsec)|alpine|Normal tfsec image|
 |[tfsec/tfsec-alpine](https://hub.docker.com/r/aquasec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
 |[tfsec/tfsec-ci](https://hub.docker.com/r/aquasec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
-|[tfsec/tfsec-scratch](https://hub.docker.com/r/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
+|[tfsec/tfsec-scratch](https://hub.docker.com/r/aquasec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
 
 To run:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ There are a number of Docker options available
 
 | Image Name | Base | Comment |
 |------------|------|---------|
-|[tfsec/tfsec](https://hub.docker.com/r/tfsec/tfsec)|alpine|Normal tfsec image|
+|[tfsec/tfsec](https://hub.docker.com/r/aquasec/tfsec)|alpine|Normal tfsec image|
 |[tfsec/tfsec-alpine](https://hub.docker.com/r/tfsec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
 |[tfsec/tfsec-ci](https://hub.docker.com/r/tfsec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
 |[tfsec/tfsec-scratch](https://hub.docker.com/r/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ There are a number of Docker options available
 |------------|------|---------|
 |[tfsec/tfsec](https://hub.docker.com/r/aquasec/tfsec)|alpine|Normal tfsec image|
 |[tfsec/tfsec-alpine](https://hub.docker.com/r/aquasec/tfsec-alpine)|alpine|Exactly the same as tfsec/tfsec, but for those whole like to be explicit|
-|[tfsec/tfsec-ci](https://hub.docker.com/r/tfsec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
+|[tfsec/tfsec-ci](https://hub.docker.com/r/aquasec/tfsec-ci)|alpine|tfsec with no entrypoint - useful for CI builds where you want to override the command|
 |[tfsec/tfsec-scratch](https://hub.docker.com/r/tfsec/tfsec-scratch)|scratch|An image built on scratch - nothing frilly, just runs tfsec|
 
 To run:


### PR DESCRIPTION
Links were pointing to a location that required Docker Hub login. Change to public link.