### PR TITLE
fix: check for gke ip_allocation_policy as a block

### DIFF
--- a/internal/app/tfsec/rules/google/gke/enable_ip_aliasing_rule.go
+++ b/internal/app/tfsec/rules/google/gke/enable_ip_aliasing_rule.go
@@ -93,6 +93,44 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     ]
   }
 }
+`,`
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
+resource "google_container_cluster" "good_example" {
+  name     = "my-gke-cluster"
+  location = "us-central1"
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  ip_allocation_policy     {
+    cluster_secondary_range_name  = "some range name"
+    services_secondary_range_name = "some range name"
+  }
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name       = "my-node-pool"
+  location   = "us-central1"
+  cluster    = google_container_cluster.primary.name
+  node_count = 1
+
+  node_config {
+    preemptible  = true
+    machine_type = "e2-medium"
+
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    service_account = google_service_account.default.email
+    oauth_scopes    = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+}
 `},
 			Links: []string{
 				"https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#ip_allocation_policy",
@@ -106,7 +144,9 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 		},
 		DefaultSeverity: severity.Low,
 		CheckFunc: func(set result.Set, resourceBlock block.Block, _ block.Module) {
-			if ipAllocationPolicyAttr := resourceBlock.GetAttribute("ip_allocation_policy"); ipAllocationPolicyAttr.IsNil() { // alert on use of default value
+			ipAllocationPolicyAttr := resourceBlock.GetAttribute("ip_allocation_policy");
+			ipAllocationPolicyBlock := resourceBlock.GetBlock("ip_allocation_policy");
+			if ipAllocationPolicyAttr.IsNil() && ipAllocationPolicyBlock.IsNil() { // alert on use of default value
 				set.AddResult().
 					WithDescription("Resource '%s' has IP aliasing disabled.", resourceBlock.FullName())
 			}


### PR DESCRIPTION
fixes: https://github.com/aquasecurity/tfsec/issues/1038

### Support `ip_allocation_policy` as a block
Adding additional condition to check if `ip_allocaiton_policy` is not a
block.

Questions:
Based on docs this is actually a `block` -
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#ip_allocation_policy.
So maybe we should remove the check for `Attribute`?