### PR TITLE
fix: no-color for severity

### DIFF
--- a/internal/app/tfsec/formatters/default.go
+++ b/internal/app/tfsec/formatters/default.go
@@ -19,15 +19,16 @@ import (
 	"github.com/liamg/tml"
 )
 
-var severityFormat = map[severity.Severity]string{
-	severity.Low:      tml.Sprintf("<white>%s</white>", severity.Low),
-	severity.Medium:   tml.Sprintf("<yellow>%s</yellow>", severity.Medium),
-	severity.High:     tml.Sprintf("<red>%s</red>", severity.High),
-	severity.Critical: tml.Sprintf("<bold><red>%s</red></bold>", severity.Critical),
-	"":                tml.Sprintf("<white>UNKNOWN</white>"),
-}
+var severityFormat map[severity.Severity]string
 
 func FormatDefault(_ io.Writer, results []result.Result, _ string, options ...FormatterOption) error {
+	severityFormat = map[severity.Severity]string{
+		severity.Low:      tml.Sprintf("<white>%s</white>", severity.Low),
+		severity.Medium:   tml.Sprintf("<yellow>%s</yellow>", severity.Medium),
+		severity.High:     tml.Sprintf("<red>%s</red>", severity.High),
+		severity.Critical: tml.Sprintf("<bold><red>%s</red></bold>", severity.Critical),
+		"":                tml.Sprintf("<white>UNKNOWN</white>"),
+	}
 
 	showStatistics := true
 	showSuccessOutput := true

--- a/internal/app/tfsec/formatters/default.go
+++ b/internal/app/tfsec/formatters/default.go
@@ -22,12 +22,14 @@ import (
 var severityFormat map[severity.Severity]string
 
 func FormatDefault(_ io.Writer, results []result.Result, _ string, options ...FormatterOption) error {
-	severityFormat = map[severity.Severity]string{
-		severity.Low:      tml.Sprintf("<white>%s</white>", severity.Low),
-		severity.Medium:   tml.Sprintf("<yellow>%s</yellow>", severity.Medium),
-		severity.High:     tml.Sprintf("<red>%s</red>", severity.High),
-		severity.Critical: tml.Sprintf("<bold><red>%s</red></bold>", severity.Critical),
-		"":                tml.Sprintf("<white>UNKNOWN</white>"),
+	if severityFormat == nil {
+		severityFormat = map[severity.Severity]string{
+			severity.Low:      tml.Sprintf("<white>%s</white>", severity.Low),
+			severity.Medium:   tml.Sprintf("<yellow>%s</yellow>", severity.Medium),
+			severity.High:     tml.Sprintf("<red>%s</red>", severity.High),
+			severity.Critical: tml.Sprintf("<bold><red>%s</red></bold>", severity.Critical),
+			"":                tml.Sprintf("<white>UNKNOWN</white>"),
+		}
 	}
 
 	showStatistics := true


### PR DESCRIPTION
fixes: https://github.com/aquasecurity/tfsec/issues/1037

#### Problem
severityFormat map was initialized before user flags were parsed by main tfsec app. These flags control `tml` parsing. Initialization of severityFormat uses `tml` so it was done with `default` values of tml - by default `no-color` is not set.

#### Fix
Moved severityFormat map generation to `runtime` context within `FormatDefault` function which will use `no-color` flag set by the user.

Added check to only populate this map if its nil.

Example:

```
  Result 1

  [aws-ecs-enable-container-insight][HIGH] Resource 'aws_ecs_cluster.bad_example' does not have containerInsights enabled
  /home/michal-franc/Work/go-src/github.com/michal-franc/tfsec/bin/linux/test.tf:1-3


       1 | resource "aws_ecs_cluster" "bad_example" {
       2 |   	name = "services-cluster"
       3 | }
       4 |
       5 |

  Legacy ID:  AWS090
  Impact:     Not all metrics and logs may be gathered for containers when Container Insights isn't enabled
  Resolution: Enable Container Insights
```