### PR TITLE
fix: do not ignore allExcludedRuleIDs params

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -378,6 +378,8 @@ func getScannerOptions() []scanner.Option {
 	}
 	allExcludedRuleIDs = mergeWithoutDuplicates(allExcludedRuleIDs, tfsecConfig.ExcludedChecks)
 
+        options = append(options, scanner.OptionExcludeRules(allExcludedRuleIDs))
+
 	var allIncludedRuleIDs []string
 	if len(includedRuleIDs) > 0 {
 		for _, include := range strings.Split(includedRuleIDs, ",") {


### PR DESCRIPTION
I believe this line has been forgotten in https://github.com/aquasecurity/tfsec/pull/1053

Resolves #1055