### PR TITLE
docker: specify the tags for the dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.14
 
 USER nobody
 # work somewhere where we can write

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.14
 # use a non-privileged user
 USER nobody
 # work somewhere where we can write

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,4 +1,4 @@
-FROM alpine as nobody
+FROM alpine:3.14 as nobody
 
 FROM scratch
 # use a non-privileged user but need to add it in


### PR DESCRIPTION
- would be good practice of specifying the base docker image tag number
- the base image tag dependencies would be managed by dependabot to ensure the latest and greatest