### PR TITLE
Added cloudfront_default_certificate check to aws-cloudfront-use-secure-tls-policy rule

### DIFF
--- a/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule.go
@@ -29,7 +29,7 @@ You should not use outdated/insecure TLS versions for encryption. You should be 
 			BadExample: []string{`
 resource "aws_cloudfront_distribution" "bad_example" {
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = false
     minimum_protocol_version = "TLSv1.0"
   }
 }
@@ -37,7 +37,7 @@ resource "aws_cloudfront_distribution" "bad_example" {
 			GoodExample: []string{`
 resource "aws_cloudfront_distribution" "good_example" {
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = false
     minimum_protocol_version = "TLSv1.2_2021"
   }
 }
@@ -57,6 +57,11 @@ resource "aws_cloudfront_distribution" "good_example" {
 			if viewerCertificateBlock.IsNil() {
 				set.AddResult().
 					WithDescription("Resource '%s' defines outdated SSL/TLS policies (missing viewer_certificate block)", resourceBlock.FullName())
+				return
+			}
+
+			defaultCertificateAttr := viewerCertificateBlock.GetAttribute("cloudfront_default_certificate")
+			if defaultCertificateAttr.IsTrue() {
 				return
 			}
 

--- a/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule_test.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule_test.go
@@ -28,7 +28,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 			source: `
 resource "aws_cloudfront_distribution" "s3_distribution" {
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = false
   }
 }`,
 			mustIncludeResultCode: expectedCode,
@@ -38,11 +38,21 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 			source: `
 resource "aws_cloudfront_distribution" "s3_distribution" {
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = false
 	minimum_protocol_version = "TLSv1.2_2018"
   }
 }`,
 			mustIncludeResultCode: expectedCode,
+		},
+		{
+			name: "check don't trigger if cloudfront_default_certificate is set to true",
+			source: `
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}`,
+			mustExcludeResultCode: expectedCode,
 		},
 	}
 


### PR DESCRIPTION
Proposed fix for issue #1082 