### PR TITLE
Fix go installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can also grab the binary for your system from the [releases page](https://gi
 Alternatively, install with Go:
 
 ```bash
-go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
+go get github.com/aquasecurity/tfsec/cmd/tfsec@latest
 ```
 
 Please note that using `go install` will install directly from the `master` branch and version numbers will not be reported via `tfsec --version`.


### PR DESCRIPTION
## Before

```console
$ go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
can't load package: package github.com/aquasecurity/tfsec/cmd/tfsec@latest: can only use path@version syntax with 'go get'
```

## After

```console
$ go get github.com/aquasecurity/tfsec/cmd/tfsec@latest
go: downloading github.com/aquasecurity/tfsec v0.58.15
go: found github.com/aquasecurity/tfsec/cmd/tfsec in github.com/aquasecurity/tfsec v0.58.15
go: downloading github.com/spf13/cobra v1.2.1
...
```