### PR TITLE
Use KMS ARN in the ECR encryption good example

### DIFF
--- a/internal/app/tfsec/rules/aws/ecr/repository_customer_key_rule.go
+++ b/internal/app/tfsec/rules/aws/ecr/repository_customer_key_rule.go
@@ -52,7 +52,7 @@ resource "aws_ecr_repository" "good_example" {
 
 	encryption_configuration {
 		encryption_type = "KMS"
-		kms_key = aws_kms_key.ecr_kms.key_id
+		kms_key = aws_kms_key.ecr_kms.arn
 	}
   }
 `},


### PR DESCRIPTION
[Good example](https://github.com/aquasecurity/tfsec/blob/master/internal/app/tfsec/rules/aws/ecr/repository_customer_key_rule.go#L53) of the ECR rule wrongly suggest to use KMS `key_id` instead of `arn` object.

From the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#encryption_configuration):

> encryption_configuration

>    encryption_type - (Optional) The encryption type to use for the repository. Valid values are AES256 or KMS. Defaults to AES256.
    kms_key - (Optional) The ARN of the KMS key to use when encryption_type is KMS. If not specified, uses the default AWS managed key for ECR.

As result if we using code from "good" example terraform would always detect false drift, as key_id is only part of ARN. 