### PR TITLE
fix tf v1.1.0 init module sources

### DIFF
--- a/internal/app/tfsec/test/module_test.go
+++ b/internal/app/tfsec/test/module_test.go
@@ -268,11 +268,23 @@ func Test_ProblemInInitialisedModule(t *testing.T) {
 
 	require.NoError(t, fs.WriteTextFile("project/main.tf", `
 module "something" {
-  	source = "/nowhere"
-	bad = true
+  	source = "../modules/somewhere"
+	bad = false
 }
 `))
-	require.NoError(t, fs.WriteTextFile("project/.terraform/modules/a/main.tf", `
+	require.NoError(t, fs.WriteTextFile("modules/somewhere/main.tf", `
+module "something_nested" {
+	count = 1
+  	source = "github.com/some/module.git"
+	bad = true
+}
+
+variable "bad" {
+	default = false
+}
+
+`))
+	require.NoError(t, fs.WriteTextFile("project/.terraform/modules/something.something_nested/main.tf", `
 variable "bad" {
 	default = false
 }
@@ -281,7 +293,7 @@ resource "problem" "uhoh" {
 }
 `))
 	require.NoError(t, fs.WriteTextFile("project/.terraform/modules/modules.json", `
-	{"Modules":[{"Key":"something","Source":"/nowhere","Version":"2.35.0","Dir":".terraform/modules/a"}]}
+	{"Modules":[{"Key":"something","Source":"../modules/somewhere","Version":"2.35.0","Dir":"../modules/somewhere"},{"Key":"something.something_nested","Source":"git::https://github.com/some/module.git","Version":"2.35.0","Dir":".terraform/modules/something.something_nested"}]}
 `))
 
 	blocks, err := parser.New(fs.RealPath("project/"), parser.OptionStopOnHCLError()).ParseDirectory()
@@ -318,7 +330,7 @@ resource "problem" "uhoh" {
 }
 `))
 	require.NoError(t, fs.WriteTextFile("project/.terraform/modules/modules.json", `
-	{"Modules":[{"Key":"something","Source":"/nowhere","Version":"2.35.0","Dir":".terraform/modules/a"}]}
+	{"Modules":[{"Key":"something","Source":"/nowhere","Version":"2.35.0","Dir":".terraform/modules/a"},{"Key":"something2","Source":"/nowhere","Version":"2.35.0","Dir":".terraform/modules/a"}]}
 `))
 
 	blocks, err := parser.New(fs.RealPath("project/"), parser.OptionStopOnHCLError()).ParseDirectory()


### PR DESCRIPTION
This PR fixes the issue with the terraform v1.1.0+ module sources
by changing matching on module source to matching on module name with module key in the json metadata file.
module source is since tf 1.1.0 no longer always equal to the source in the metadata json file(.terraform\modules\modules.json) ,for instance terraform/hashicorp auto resolves to registry.terraform.com, googleapis.com to gcs etc..
see issue #1188 
