### PR TITLE
Azure compute - adapt to use defsec

### DIFF
--- a/internal/app/tfsec/adapter/azure/compute/adapt.go
+++ b/internal/app/tfsec/adapter/azure/compute/adapt.go
@@ -1,10 +1,119 @@
 package compute
 
 import (
+	"encoding/base64"
+
 	"github.com/aquasecurity/defsec/provider/azure/compute"
+	"github.com/aquasecurity/defsec/types"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) compute.Compute {
-	return compute.Compute{}
+	return adaptCompute(modules)
+}
+
+func adaptCompute(modules []block.Module) compute.Compute {
+
+	var managedDisks []compute.ManagedDisk
+	var linuxVirtualMachines []compute.LinuxVirtualMachine
+	var windowsVirtualMachines []compute.WindowsVirtualMachine
+
+	for _, module := range modules {
+
+		for _, resource := range module.GetResourcesByType("azurerm_linux_virtual_machine") {
+			linuxVirtualMachines = append(linuxVirtualMachines, adaptLinuxVM(resource))
+		}
+		for _, resource := range module.GetResourcesByType("azurerm_windows_virtual_machine") {
+			windowsVirtualMachines = append(windowsVirtualMachines, adaptWindowsVM(resource))
+		}
+		for _, resource := range module.GetResourcesByType("azurerm_virtual_machine") {
+			if resource.HasChild("os_profile_linux_config") {
+				linuxVirtualMachines = append(linuxVirtualMachines, adaptLinuxVM(resource))
+			} else if resource.HasChild("os_profile_windows_config") {
+				windowsVirtualMachines = append(windowsVirtualMachines, adaptWindowsVM(resource))
+			}
+		}
+		for _, resource := range module.GetResourcesByType("azurerm_managed_disk") {
+			managedDisks = append(managedDisks, adaptManagedDisk(resource))
+		}
+	}
+
+	return compute.Compute{
+		LinuxVirtualMachines:   linuxVirtualMachines,
+		WindowsVirtualMachines: windowsVirtualMachines,
+		ManagedDisks:           managedDisks,
+	}
+}
+
+func adaptManagedDisk(resource block.Block) compute.ManagedDisk {
+	encryptionBlock := resource.GetBlock("encryption_settings")
+	var enabledVal types.BoolValue
+
+	if encryptionBlock.IsNotNil() {
+		enabledAttr := encryptionBlock.GetAttribute("enabled")
+		enabledVal = enabledAttr.AsBoolValueOrDefault(false, encryptionBlock)
+	}
+
+	return compute.ManagedDisk{
+		Encryption: compute.Encryption{
+			Enabled: enabledVal,
+		},
+	}
+}
+
+func adaptLinuxVM(resource block.Block) compute.LinuxVirtualMachine {
+	workingBlock := resource
+
+	if resource.TypeLabel() == "azurerm_virtual_machine" {
+		workingBlock = resource.GetBlock("os_profile")
+	}
+	customDataAttr := workingBlock.GetAttribute("custom_data")
+	var customDataVal types.StringValue
+	if customDataAttr.IsResolvable() && customDataAttr.IsString() {
+		encoded, err := base64.StdEncoding.DecodeString(customDataAttr.Value().AsString())
+		if err != nil {
+			encoded = []byte(customDataAttr.Value().AsString())
+		}
+		customDataVal = types.String(string(encoded), *workingBlock.GetMetadata())
+	}
+
+	if resource.TypeLabel() == "azurerm_virtual_machine" {
+		workingBlock = resource.GetBlock("os_profile_linux_config")
+	}
+	disablePasswordAuthAttr := workingBlock.GetAttribute("disable_password_authentication")
+	disablePasswordAuthVal := disablePasswordAuthAttr.AsBoolValueOrDefault(true, workingBlock)
+
+	return compute.LinuxVirtualMachine{
+		VirtualMachine: compute.VirtualMachine{
+			CustomData: customDataVal,
+		},
+		OSProfileLinuxConfig: compute.OSProfileLinuxConfig{
+			DisablePasswordAuthentication: disablePasswordAuthVal,
+		},
+	}
+}
+
+func adaptWindowsVM(resource block.Block) compute.WindowsVirtualMachine {
+	workingBlock := resource
+
+	if resource.TypeLabel() == "azurerm_virtual_machine" {
+		workingBlock = resource.GetBlock("os_profile")
+	}
+
+	customDataAttr := workingBlock.GetAttribute("custom_data")
+	var customDataVal types.StringValue
+
+	if customDataAttr.IsResolvable() && customDataAttr.IsString() {
+		encoded, err := base64.StdEncoding.DecodeString(customDataAttr.Value().AsString())
+		if err != nil {
+			encoded = []byte(customDataAttr.Value().AsString())
+		}
+		customDataVal = types.String(string(encoded), *workingBlock.GetMetadata())
+	}
+
+	return compute.WindowsVirtualMachine{
+		VirtualMachine: compute.VirtualMachine{
+			CustomData: customDataVal,
+		},
+	}
 }

--- a/internal/app/tfsec/rules/azure/compute/disable_password_authentication_rule.go
+++ b/internal/app/tfsec/rules/azure/compute/disable_password_authentication_rule.go
@@ -1,9 +1,7 @@
 package compute
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/compute"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -80,24 +78,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_linux_virtual_machine", "azurerm_virtual_machine"},
 		Base:           compute.CheckDisablePasswordAuthentication,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			workingBlock := resourceBlock
-			if resourceBlock.TypeLabel() == "azurerm_virtual_machine" {
-				if resourceBlock.HasChild("os_profile_linux_config") {
-					workingBlock = resourceBlock.GetBlock("os_profile_linux_config")
-				}
-			}
-
-			if workingBlock.MissingChild("disable_password_authentication") {
-				return
-			}
-
-			passwordAuthAttr := workingBlock.GetAttribute("disable_password_authentication")
-			if passwordAuthAttr.IsFalse() {
-				results.Add("Resource has password authentication enabled.", passwordAuthAttr)
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/compute/enable_disk_encryption_rule.go
+++ b/internal/app/tfsec/rules/azure/compute/enable_disk_encryption_rule.go
@@ -1,9 +1,7 @@
 package compute
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/compute"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -29,22 +27,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_managed_disk"},
 		Base:           compute.CheckEnableDiskEncryption,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-			encryptionSettingsBlock := resourceBlock.GetBlock("encryption_settings")
-			if encryptionSettingsBlock.IsNil() {
-				return // encryption is by default now, so this is fine
-			}
-
-			if encryptionSettingsBlock.MissingChild("enabled") {
-				return
-			}
-
-			enabledAttr := encryptionSettingsBlock.GetAttribute("enabled")
-			if enabledAttr.IsFalse() {
-				results.Add("Resource defines an unencrypted managed disk.", enabledAttr)
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/compute/no_secrets_in_custom_data_rule.go
+++ b/internal/app/tfsec/rules/azure/compute/no_secrets_in_custom_data_rule.go
@@ -1,16 +1,10 @@
 package compute
 
 import (
-	"encoding/base64"
-
 	"github.com/aquasecurity/defsec/rules/azure/compute"
 
-	"github.com/aquasecurity/defsec/rules"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/debug"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
-	"github.com/owenrumney/squealer/pkg/squealer"
 )
 
 func init() {
@@ -18,17 +12,27 @@ func init() {
 		BadExample: []string{`
  resource "azurerm_virtual_machine" "bad_example" {
  	name = "bad_example"
- 	custom_data =<<EOF
- export DATABASE_PASSWORD=\"SomeSortOfPassword\"
- EOF
+	os_profile_linux_config {
+		disable_password_authentication = false
+	}
+	os_profile {
+		custom_data =<<EOF
+			export DATABASE_PASSWORD=\"SomeSortOfPassword\"
+			EOF
+	}
  }
  `},
 		GoodExample: []string{`
  resource "azurerm_virtual_machine" "good_example" {
  	name = "good_example"
- 	custom_data =<<EOF
- export GREETING="Hello there"
- EOF
+	os_profile_linux_config {
+		disable_password_authentication = false
+	}
+	os_profile {
+		custom_data =<<EOF
+			export GREETING="Hello there"
+			EOF
+	}
  }
  `},
 		Links: []string{
@@ -37,36 +41,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_virtual_machine", "azurerm_linux_virtual_machine", "azurerm_windows_virtual_machine"},
 		Base:           compute.CheckNoSecretsInCustomData,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("custom_data") {
-				return
-			}
-
-			customDataAttr := resourceBlock.GetAttribute("custom_data")
-
-			if resourceBlock.TypeLabel() == "azurerm_virtual_machine" {
-				for _, str := range customDataAttr.ValueAsStrings() {
-					if checkStringForSensitive(str) {
-						results.Add("Resource has custom_data with sensitive data.", customDataAttr)
-					}
-				}
-			} else if customDataAttr.IsResolvable() && customDataAttr.IsString() {
-				encoded, err := base64.StdEncoding.DecodeString(customDataAttr.Value().AsString())
-				if err != nil {
-					debug.Log("could not decode the base64 string in the terraform, trying with the string verbatim")
-					encoded = []byte(customDataAttr.Value().AsString())
-				}
-				if checkStringForSensitive(string(encoded)) {
-					results.Add("Resource has custom_data with sensitive data.", customDataAttr)
-				}
-
-			}
-			return results
-		},
 	})
-}
-
-func checkStringForSensitive(stringToCheck string) bool {
-	return squealer.NewStringScanner().Scan(stringToCheck).TransgressionFound
 }

--- a/internal/app/tfsec/rules/azure/compute/no_secrets_in_custom_data_rule_test.go
+++ b/internal/app/tfsec/rules/azure/compute/no_secrets_in_custom_data_rule_test.go
@@ -20,9 +20,14 @@ func Test_AzureNoSecretsInCustomData(t *testing.T) {
 			source: `
  			resource "azurerm_virtual_machine" "bad_example" {
  				name = "bad_example"
- 				custom_data =<<EOF
- DATABASE_PASSWORD=SomeSortOfPassword
- EOF
+				os_profile_windows_config {
+					disable_password_authentication = false
+				}
+				os_profile {
+					custom_data =<<EOF
+						DATABASE_PASSWORD=SomeSortOfPassword
+						EOF
+				}
  			}
  `,
 			mustIncludeResultCode: expectedCode,
@@ -32,9 +37,14 @@ func Test_AzureNoSecretsInCustomData(t *testing.T) {
 			source: `
  			resource "azurerm_virtual_machine" "bad_example" {
  				name = "bad_example"
- 				custom_data =<<EOF
- DATABASE_PASSWORD="SomeSortOfPassword"
- EOF
+				os_profile_windows_config {
+					disable_password_authentication = false
+				}
+				os_profile {
+ 					custom_data =<<EOF
+ 						DATABASE_PASSWORD="SomeSortOfPassword"
+ 						EOF
+				}
  			}
  `,
 			mustIncludeResultCode: expectedCode,
@@ -52,11 +62,16 @@ func Test_AzureNoSecretsInCustomData(t *testing.T) {
 		{
 			name: "virtual machine with no sensitive information in custom_data passes check",
 			source: `
- resource "azurerm_virtual_machine" "god_example" {
+ resource "azurerm_virtual_machine" "good_example" {
  				name = "good_example"
- 				custom_data =<<EOF
- GREETING_TEXT="Hello"
- EOF
+				os_profile_windows_config {
+					disable_password_authentication = false
+				}
+				os_profile {
+					custom_data =<<EOF
+						GREETING_TEXT="Hello"
+						EOF
+				}
  			}
  `,
 			mustExcludeResultCode: expectedCode,
@@ -64,7 +79,7 @@ func Test_AzureNoSecretsInCustomData(t *testing.T) {
 		{
 			name: "linux virtual machine with no sensitive information in base64 custom_data passes check",
 			source: `
- resource "azurerm_linux_virtual_machine" "god_example" {
+ resource "azurerm_linux_virtual_machine" "good_example" {
  				name = "good_example"
  				custom_data = "ZXhwb3J0IEVESVRPUj12aW1hY3M=" 
  			}


### PR DESCRIPTION
Write the adapters for the virtual machines and the managed disks

According to the Terraform docs: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine#custom_data
 the `custom_data` attribute is part of the `os_profile` block. Update examples and tests accordingly. 

Update examples and tests to include either `os_profile_linux_config` or `os_profile_windows_config` block. One of them is always required by Terraform depending on the os and as such is used by the adapter to classify the virtual machine by os.

Closes: https://github.com/aquasecurity/tfsec/issues/1233