### PR TITLE
Azure storage - adapt to use defsec logic

### DIFF
--- a/internal/app/tfsec/adapter/azure/storage/adapt.go
+++ b/internal/app/tfsec/adapter/azure/storage/adapt.go
@@ -2,9 +2,116 @@ package storage
 
 import (
 	"github.com/aquasecurity/defsec/provider/azure/storage"
+	"github.com/aquasecurity/defsec/types"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) storage.Storage {
-	return storage.Storage{}
+	return storage.Storage{
+		Accounts: adaptAccounts(modules),
+	}
+}
+
+func adaptAccounts(modules []block.Module) []storage.Account {
+	var accounts []storage.Account
+
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("azurerm_storage_account") {
+			account := adaptAccount(resource)
+			containerResource := module.GetReferencingResources(resource, "azurerm_storage_container", "storage_account_name")
+			for _, containerBlock := range containerResource {
+				account.Containers = append(account.Containers, adaptContainer(containerBlock))
+			}
+			networkRulesResource := module.GetReferencingResources(resource, "azurerm_storage_account_network_rules", "storage_account_name")
+			for _, networkRuleBlock := range networkRulesResource {
+				account.NetworkRules = append(account.NetworkRules, adaptNetworkRule(networkRuleBlock))
+			}
+			accounts = append(accounts, account)
+		}
+
+		if len(module.GetResourcesByType("azurerm_storage_account")) == 0 {
+			for _, resource := range module.GetResourcesByType("azurerm_storage_account_network_rules") {
+				accounts = append(accounts, storage.Account{
+					NetworkRules: []storage.NetworkRule{
+						adaptNetworkRule(resource),
+					},
+				})
+			}
+		}
+	}
+
+	return accounts
+}
+
+func adaptAccount(resource block.Block) storage.Account {
+	var networkRules []storage.NetworkRule
+	networkRulesBlocks := resource.GetBlocks("network_rules")
+	for _, networkBlock := range networkRulesBlocks {
+		networkRules = append(networkRules, adaptNetworkRule(networkBlock))
+	}
+
+	httpsOnlyAttr := resource.GetAttribute("enable_https_traffic_only")
+	httpsOnlyVal := httpsOnlyAttr.AsBoolValueOrDefault(true, resource)
+
+	enableLogging := types.Bool(false, *resource.GetMetadata())
+	queuePropertiesBlock := resource.GetBlock("queue_properties")
+	if queuePropertiesBlock.IsNotNil() {
+		loggingBlock := queuePropertiesBlock.GetBlock("logging")
+		if loggingBlock.IsNotNil() {
+			enableLogging = types.Bool(true, *loggingBlock.GetMetadata())
+		}
+	}
+
+	minTLSVersionAttr := resource.GetAttribute("min_tls_version")
+	minTLSVersionVal := minTLSVersionAttr.AsStringValueOrDefault("TLS1_0", resource)
+
+	return storage.Account{
+		NetworkRules: networkRules,
+		EnforceHTTPS: httpsOnlyVal,
+		QueueProperties: storage.QueueProperties{
+			EnableLogging: enableLogging,
+		},
+		MinimumTLSVersion: minTLSVersionVal,
+	}
+}
+
+func adaptContainer(resource block.Block) storage.Container {
+	accessTypeAttr := resource.GetAttribute("container_access_type")
+	publicAccess := types.String(storage.PublicAccessOff, *resource.GetMetadata())
+
+	if accessTypeAttr.Equals("blob") {
+		publicAccess = types.String(storage.PublicAccessBlob, *resource.GetMetadata())
+	} else if accessTypeAttr.Equals("container") {
+		publicAccess = types.String(storage.PublicAccessContainer, *resource.GetMetadata())
+	}
+
+	return storage.Container{
+		PublicAccess: publicAccess,
+	}
+}
+
+func adaptNetworkRule(resource block.Block) storage.NetworkRule {
+	var allowByDefault types.BoolValue
+	var bypass []types.StringValue
+
+	defaultActionAttr := resource.GetAttribute("default_action")
+	if defaultActionAttr.Equals("allow", block.IgnoreCase) {
+		allowByDefault = types.Bool(true, *resource.GetMetadata())
+	} else if defaultActionAttr.Equals("deny", block.IgnoreCase) {
+		allowByDefault = types.Bool(false, *resource.GetMetadata())
+	}
+
+	if resource.HasChild("bypass") {
+		bypassAttr := resource.GetAttribute("bypass")
+		bypassList := bypassAttr.ValueAsStrings()
+		for _, bypassVal := range bypassList {
+			bypass = append(bypass, types.String(bypassVal, *resource.GetMetadata()))
+		}
+	}
+
+	return storage.NetworkRule{
+		Metadata:       *resource.GetMetadata(),
+		Bypass:         bypass,
+		AllowByDefault: allowByDefault,
+	}
 }

--- a/internal/app/tfsec/rules/azure/storage/allow_microsoft_service_bypass_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/allow_microsoft_service_bypass_rule.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -80,23 +78,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account_network_rules", "azurerm_storage_account"},
 		Base:           storage.CheckAllowMicrosoftServiceBypass,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.IsResourceType("azurerm_storage_account") {
-				if resourceBlock.MissingChild("network_rules") {
-					return
-				}
-				resourceBlock = resourceBlock.GetBlock("network_rules")
-			}
-
-			if resourceBlock.HasChild("bypass") {
-				bypass := resourceBlock.GetAttribute("bypass")
-				if bypass.IsNotNil() && !bypass.Contains("AzureServices") {
-					results.Add("Resource defines a network rule that doesn't allow bypass of Microsoft Services.", bypass)
-				}
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/storage/default_action_deny_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/default_action_deny_rule.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -35,21 +33,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account", "azurerm_storage_account_network_rules"},
 		Base:           storage.CheckDefaultActionDeny,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.IsResourceType("azurerm_storage_account") {
-				if resourceBlock.MissingChild("network_rules") {
-					return
-				}
-				resourceBlock = resourceBlock.GetBlock("network_rules")
-			}
-
-			defaultAction := resourceBlock.GetAttribute("default_action")
-			if defaultAction.IsNotNil() && defaultAction.Equals("Allow", block.IgnoreCase) {
-				results.Add("Resource defines a default_action of Allow. It should be Deny.", defaultAction)
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/storage/enforce_https_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/enforce_https_rule.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -37,18 +35,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
 		Base:           storage.CheckEnforceHttps,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.HasChild("enable_https_traffic_only") {
-
-				httpsOnlyAttr := resourceBlock.GetAttribute("enable_https_traffic_only")
-
-				if httpsOnlyAttr.IsFalse() {
-					results.Add("Resource explicitly turns off secure transfer to storage account.", httpsOnlyAttr)
-				}
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/storage/no_public_access_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/no_public_access_rule.go
@@ -1,56 +1,41 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func init() {
 	scanner.RegisterCheckRule(rule.Rule{
 		LegacyID: "AZU011",
 		BadExample: []string{`
- resource "azure_storage_container" "bad_example" {
+ resource "azurerm_storage_account" "example" {
+	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "bad_example" {
  	name                  = "terraform-container-storage"
+	storage_account_name  = azurerm_storage_account.example.name
  	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "blob"
- 	}
  }
  `},
 		GoodExample: []string{`
- resource "azure_storage_container" "good_example" {
+ resource "azurerm_storage_account" "example" {
+	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "good_example" {
  	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "off"
- 	}
+	storage_account_name  = azurerm_storage_account.example.name
+ 	container_access_type = "private"
  }
  `},
 		Links: []string{
-			"https://www.terraform.io/docs/providers/azure/r/storage_container.html#properties",
+			"https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container",
 		},
 		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azure_storage_container"},
+		RequiredLabels: []string{"azurerm_storage_container"},
 		Base:           storage.CheckNoPublicAccess,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("properties") {
-				return
-			}
-			properties := resourceBlock.GetAttribute("properties")
-			if properties.Contains("publicAccess") {
-				value := properties.MapValue("publicAccess")
-				if value == cty.StringVal("blob") || value == cty.StringVal("container") {
-					results.Add("Resource should disable public access.", properties)
-				}
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/storage/no_public_access_rule_test.go
+++ b/internal/app/tfsec/rules/azure/storage/no_public_access_rule_test.go
@@ -16,68 +16,75 @@ func Test_AZUBlobStorageContainerNoPublicAccess(t *testing.T) {
 		mustExcludeResultCode string
 	}{
 		{
-			name: "check there is an error when the public access is set to blob",
+			name: "check there is an error when the container access type is set to blob",
 			source: `
- resource "azure_storage_container" "blob_storage_container" {
- 	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "blob"
- 	}
+ resource "azurerm_storage_account" "example" {
+	name                     = "examplestoraccount"
  }
- `,
-			mustIncludeResultCode: expectedCode,
-		},
-		{
-			name: "check there is an error when the public access is set to container",
-			source: `
- resource "azure_storage_container" "blob_storage_container" {
- 	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "container"
- 	}
- }
- `,
-			mustIncludeResultCode: expectedCode,
-		},
-		{
-			name: "check there is no failure when the public access is set to off",
-			source: `
- resource "azure_storage_container" "blob_storage_container" {
- 	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "off"
- 	}
- }
- `,
-			mustExcludeResultCode: expectedCode,
-		},
-		{
-			name: "check there is no failure when public access level is not set",
-			source: `
- resource "azure_storage_container" "blob_storage_container" {
- 	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
- 	
- 	properties = {
- 		"publicAccess" = "off"
- 	}
- }
- `,
-			mustExcludeResultCode: expectedCode,
-		},
-		{
-			name: "check there is no failure when no properties are supplied",
-			source: `
- resource "azure_storage_container" "blob_storage_container" {
- 	name                  = "terraform-container-storage"
- 	container_access_type = "blob"
  
+ resource "azurerm_storage_container" "blob_storage_container" {
+ 	name                  = "terraform-container-storage"
+ 	container_access_type = "blob"
+	storage_account_name  = azurerm_storage_account.example.name
+ }
+ `,
+			mustIncludeResultCode: expectedCode,
+		},
+		{
+			name: "check there is an error when the container access type is set to container",
+			source: `
+ resource "azurerm_storage_account" "example" {
+	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "blob_storage_container" {
+ 	name                  = "terraform-container-storage"
+	storage_account_name  = azurerm_storage_account.example.name
+ 	container_access_type = "container"
+ }
+ `,
+			mustIncludeResultCode: expectedCode,
+		},
+		{
+			name: "check there is no failure when the container access type is set to private",
+			source: `
+ resource "azurerm_storage_account" "example" {
+ 	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "blob_storage_container" {
+ 	name                  = "terraform-container-storage"
+	storage_account_name  = azurerm_storage_account.example.name
+ 	container_access_type = "private"
+ }
+ `,
+			mustExcludeResultCode: expectedCode,
+		},
+		{
+			name: "check there is no failure when container access type is not set",
+			source: `
+ resource "azurerm_storage_account" "example" {
+ 	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "blob_storage_container" {
+ 	name                  = "terraform-container-storage"
+	storage_account_name  = azurerm_storage_account.example.name
+	container_access_type = ""
+ }
+ `,
+			mustExcludeResultCode: expectedCode,
+		},
+		{
+			name: "check there is no failure when no container access type is supplied",
+			source: `
+ resource "azurerm_storage_account" "example" {
+	name                     = "examplestoraccount"
+ }
+
+ resource "azurerm_storage_container" "blob_storage_container" {
+ 	name                  = "terraform-container-storage"
+	storage_account_name  = azurerm_storage_account.example.name
  }
  `,
 			mustExcludeResultCode: expectedCode,

--- a/internal/app/tfsec/rules/azure/storage/queue_services_logging_enabled_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/queue_services_logging_enabled_rule.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -46,17 +44,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
 		Base:           storage.CheckQueueServicesLoggingEnabled,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("queue_properties") {
-				return
-			}
-			queueProps := resourceBlock.GetBlock("queue_properties")
-			if queueProps.MissingChild("logging") {
-				results.Add("Resource defines a Queue Services storage account without Storage Analytics logging.", queueProps)
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/azure/storage/use_secure_tls_policy_rule.go
+++ b/internal/app/tfsec/rules/azure/storage/use_secure_tls_policy_rule.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/azure/storage"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -32,18 +30,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
 		Base:           storage.CheckUseSecureTlsPolicy,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("min_tls_version") {
-				results.Add("Resource should have the min tls version set to TLS1_2 .", resourceBlock)
-				return
-			}
-
-			minTlsAttr := resourceBlock.GetAttribute("min_tls_version")
-			if minTlsAttr.IsNone("TLS1_2") {
-				results.Add("Resource should have the min tls version set to TLS1_2 .", minTlsAttr)
-			}
-			return results
-		},
 	})
 }


### PR DESCRIPTION
Write azure storage adapter.

Update resource `"azure_storage_container"` to `"azurerm_storage_container"` as per the latest [docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container).
Azure container resource in Terraform no longer includes a `properties` block and as such the `no_public_access_rule` has been modified to check the value in the `container_access_type` attribute. 
But it's up to the maintainers to decide if the rule should be kept at all.

An `"azurerm_storage_account"` resource has been added to the container examples, since its existence is already [required](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container#storage_account_name) by Terraform, it is used to classify which account the containers belong to. 

Closes: https://github.com/aquasecurity/tfsec/issues/1221