### PR TITLE
Digital Ocean spaces - update to use defsec

### DIFF
--- a/internal/app/tfsec/adapter/digitalocean/spaces/adapt.go
+++ b/internal/app/tfsec/adapter/digitalocean/spaces/adapt.go
@@ -1,10 +1,61 @@
 package spaces
 
 import (
+	"github.com/aquasecurity/defsec/types"
+
 	"github.com/aquasecurity/defsec/provider/digitalocean/spaces"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) spaces.Spaces {
-	return spaces.Spaces{}
+	return spaces.Spaces{
+		Buckets: adaptBuckets(modules),
+	}
+}
+
+func adaptBuckets(modules []block.Module) []spaces.Bucket {
+	var buckets []spaces.Bucket
+
+	for _, module := range modules {
+		for _, resourceBlock := range module.GetResourcesByType("digitalocean_spaces_bucket") {
+			bucket := adaptBucket(resourceBlock)
+			for _, objectBlock := range module.GetReferencingResources(resourceBlock, "digitalocean_spaces_bucket_object", "bucket") {
+				bucket.Objects = append(bucket.Objects, adaptObject(objectBlock))
+			}
+			buckets = append(buckets, bucket)
+		}
+	}
+	return buckets
+}
+
+func adaptBucket(resourceBlock block.Block) spaces.Bucket {
+	aclAttr := resourceBlock.GetAttribute("acl")
+	aclVal := aclAttr.AsStringValueOrDefault("", resourceBlock)
+
+	forceDestroyAttr := resourceBlock.GetAttribute("force_destroy")
+	forceDestroyVal := forceDestroyAttr.AsBoolValueOrDefault(false, resourceBlock)
+
+	versioningBlock := resourceBlock.GetBlock("versioning")
+	enabledVal := types.Bool(false, *resourceBlock.GetMetadata())
+	if versioningBlock.IsNotNil() {
+		enabledAttr := versioningBlock.GetAttribute("enabled")
+		enabledVal = enabledAttr.AsBoolValueOrDefault(false, versioningBlock)
+	}
+
+	return spaces.Bucket{
+		ACL:          aclVal,
+		ForceDestroy: forceDestroyVal,
+		Versioning: spaces.Versioning{
+			Enabled: enabledVal,
+		},
+	}
+}
+
+func adaptObject(resource block.Block) spaces.Object {
+	aclAttr := resource.GetAttribute("acl")
+	aclVal := aclAttr.AsStringValueOrDefault("", resource)
+
+	return spaces.Object{
+		ACL: aclVal,
+	}
 }

--- a/internal/app/tfsec/rules/digitalocean/spaces/acl_no_public_read_rule.go
+++ b/internal/app/tfsec/rules/digitalocean/spaces/acl_no_public_read_rule.go
@@ -1,9 +1,7 @@
 package spaces
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/digitalocean/spaces"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -49,15 +47,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"digitalocean_spaces_bucket", "digitalocean_spaces_bucket_object"},
 		Base:           spaces.CheckAclNoPublicRead,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.HasChild("acl") {
-				aclAttr := resourceBlock.GetAttribute("acl")
-				if aclAttr.Equals("public-read", block.IgnoreCase) {
-					results.Add("Resource has a publicly readable acl.", aclAttr)
-				}
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/digitalocean/spaces/acl_no_public_read_rule_test.go
+++ b/internal/app/tfsec/rules/digitalocean/spaces/acl_no_public_read_rule_test.go
@@ -29,6 +29,9 @@ func Test_DIGPublicReadAclOnSpacesBucket(t *testing.T) {
 		{
 			name: "Spaces bucket object with public-read acl fails check",
 			source: `
+ resource "digitalocean_spaces_bucket" "bad_example" {
+	name   = "foobar"
+ }
  resource "digitalocean_spaces_bucket_object" "index" {
    region       = digitalocean_spaces_bucket.bad_example.region
    bucket       = digitalocean_spaces_bucket.bad_example.name
@@ -43,6 +46,9 @@ func Test_DIGPublicReadAclOnSpacesBucket(t *testing.T) {
 		{
 			name: "Spaces bucket object using default acl (private) passes check",
 			source: `
+resource "digitalocean_spaces_bucket" "good_example" {
+	name   = "foobar"
+}
  resource "digitalocean_spaces_bucket_object" "index" {
    region       = digitalocean_spaces_bucket.good_example.region
    bucket       = digitalocean_spaces_bucket.good_example.name

--- a/internal/app/tfsec/rules/digitalocean/spaces/disable_force_destroy_rule.go
+++ b/internal/app/tfsec/rules/digitalocean/spaces/disable_force_destroy_rule.go
@@ -1,9 +1,7 @@
 package spaces
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/digitalocean/spaces"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -30,14 +28,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"digitalocean_spaces_bucket"},
 		Base:           spaces.CheckDisableForceDestroy,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-			if resourceBlock.HasChild("force_destroy") {
-				forceDestroyAttr := resourceBlock.GetAttribute("force_destroy")
-				if forceDestroyAttr.IsTrue() {
-					results.Add("Resource has versioning specified, but it isn't enabled", forceDestroyAttr)
-				}
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/digitalocean/spaces/versioning_enabled_rule.go
+++ b/internal/app/tfsec/rules/digitalocean/spaces/versioning_enabled_rule.go
@@ -1,9 +1,7 @@
 package spaces
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/digitalocean/spaces"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -42,23 +40,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"digitalocean_spaces_bucket"},
 		Base:           spaces.CheckVersioningEnabled,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("versioning") {
-				results.Add("Resource does not have versioning block specified", resourceBlock)
-				return
-			}
-
-			versioningBlock := resourceBlock.GetBlock("versioning")
-			enabledAttr := versioningBlock.GetAttribute("enabled")
-
-			if enabledAttr.IsNil() {
-				results.Add("Resource has versioning specified, but it isn't enabled", resourceBlock)
-			} else if enabledAttr.IsFalse() {
-				results.Add("Resource has versioning specified, but it isn't enabled", enabledAttr)
-			}
-
-			return results
-		},
 	})
 }


### PR DESCRIPTION
Create Digital Ocean spaces adapter

Add `"digitalocean_spaces_bucket"` resource to the `"digitalocean_spaces_bucket_object"`. A bucket resource is required by the object, and as such is used to classify which bucket the objects belong to. 

Closes: https://github.com/aquasecurity/tfsec/issues/1256