### PR TITLE
AWS ECS - convert tfsec checks to use defsec logic

### DIFF
--- a/internal/app/tfsec/adapter/aws/ecs/adapt.go
+++ b/internal/app/tfsec/adapter/aws/ecs/adapt.go
@@ -2,9 +2,91 @@ package ecs
 
 import (
 	"github.com/aquasecurity/defsec/provider/aws/ecs"
+	"github.com/aquasecurity/defsec/types"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) ecs.ECS {
-	return ecs.ECS{}
+	return ecs.ECS{
+		Clusters:        adaptClusters(modules),
+		TaskDefinitions: adaptTaskDefinitions(modules),
+	}
+}
+
+func adaptClusters(modules []block.Module) []ecs.Cluster {
+	var clusters []ecs.Cluster
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_ecs_cluster") {
+			clusters = append(clusters, adaptClusterResource(resource))
+		}
+	}
+	return clusters
+}
+
+func adaptClusterResource(resourceBlock block.Block) ecs.Cluster {
+	return ecs.Cluster{
+		Metadata: resourceBlock.Metadata(),
+		Settings: adaptClusterSettings(resourceBlock),
+	}
+}
+
+func adaptClusterSettings(resourceBlock block.Block) ecs.ClusterSettings {
+	if settingBlock := resourceBlock.GetBlock("setting"); settingBlock.IsNotNil() && settingBlock.GetAttribute("name").Equals("containerInsights") {
+		containerInsightsEnabled := settingBlock.GetAttribute("value").Equals("enabled")
+		return ecs.ClusterSettings{
+			ContainerInsightsEnabled: types.Bool(containerInsightsEnabled, settingBlock.Metadata()),
+		}
+	}
+
+	return ecs.ClusterSettings{
+		ContainerInsightsEnabled: types.Bool(false, resourceBlock.Metadata()),
+	}
+}
+
+func adaptTaskDefinitions(modules []block.Module) []ecs.TaskDefinition {
+	var taskDefinitions []ecs.TaskDefinition
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_ecs_task_definition") {
+			taskDefinitions = append(taskDefinitions, adaptTaskDefinitionResource(resource))
+		}
+	}
+	return taskDefinitions
+}
+
+func adaptTaskDefinitionResource(resourceBlock block.Block) ecs.TaskDefinition {
+	return ecs.TaskDefinition{
+		Metadata:             resourceBlock.Metadata(),
+		Volumes:              adaptVolumes(resourceBlock),
+		ContainerDefinitions: resourceBlock.GetAttribute("container_definitions").AsStringValueOrDefault("", resourceBlock),
+	}
+}
+
+func adaptVolumes(resourceBlock block.Block) []ecs.Volume {
+	if volumeBlocks := resourceBlock.GetBlocks("volume"); len(volumeBlocks) > 0 {
+		var volumes []ecs.Volume
+		for _, volumeBlock := range volumeBlocks {
+			volumes = append(volumes, ecs.Volume{
+				Metadata:               volumeBlock.Metadata(),
+				EFSVolumeConfiguration: adaptEFSVolumeConfiguration(volumeBlock),
+			})
+		}
+		return volumes
+	}
+
+	return []ecs.Volume{}
+}
+
+func adaptEFSVolumeConfiguration(volumeBlock block.Block) ecs.EFSVolumeConfiguration {
+	if EFSConfigBlock := volumeBlock.GetBlock("efs_volume_configuration"); EFSConfigBlock.IsNotNil() {
+		transitEncryptionEnabled := EFSConfigBlock.GetAttribute("transit_encryption").Equals("ENABLED")
+		return ecs.EFSVolumeConfiguration{
+			Metadata:                 EFSConfigBlock.Metadata(),
+			TransitEncryptionEnabled: types.Bool(transitEncryptionEnabled, EFSConfigBlock.Metadata()),
+		}
+	}
+
+	return ecs.EFSVolumeConfiguration{
+		Metadata:                 volumeBlock.Metadata(),
+		TransitEncryptionEnabled: types.Bool(true, volumeBlock.Metadata()),
+	}
 }

--- a/internal/app/tfsec/adapter/aws/ecs/adapt.go
+++ b/internal/app/tfsec/adapter/aws/ecs/adapt.go
@@ -39,7 +39,7 @@ func adaptClusterSettings(resourceBlock block.Block) ecs.ClusterSettings {
 	}
 
 	return ecs.ClusterSettings{
-		ContainerInsightsEnabled: types.Bool(false, resourceBlock.Metadata()),
+		ContainerInsightsEnabled: types.BoolDefault(false, resourceBlock.Metadata()),
 	}
 }
 
@@ -87,6 +87,6 @@ func adaptEFSVolumeConfiguration(volumeBlock block.Block) ecs.EFSVolumeConfigura
 
 	return ecs.EFSVolumeConfiguration{
 		Metadata:                 volumeBlock.Metadata(),
-		TransitEncryptionEnabled: types.Bool(true, volumeBlock.Metadata()),
+		TransitEncryptionEnabled: types.BoolDefault(true, volumeBlock.Metadata()),
 	}
 }

--- a/internal/app/tfsec/rules/aws/ecs/enable_container_insight_rule.go
+++ b/internal/app/tfsec/rules/aws/ecs/enable_container_insight_rule.go
@@ -1,9 +1,7 @@
 package ecs
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/ecs"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -32,21 +30,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_cluster"},
 		Base:           ecs.CheckEnableContainerInsight,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			settingsBlock := resourceBlock.GetBlocks("setting")
-			for _, setting := range settingsBlock {
-				if name := setting.GetAttribute("name"); name.IsNotNil() && name.Equals("containerinsights", block.IgnoreCase) {
-					if valueAttr := setting.GetAttribute("value"); valueAttr.IsNotNil() {
-						if !valueAttr.Equals("enabled", block.IgnoreCase) {
-							results.Add("Resource has containerInsights set to disabled", valueAttr)
-						}
-						return
-					}
-				}
-			}
-			results.Add("Resource does not have containerInsights enabled", resourceBlock)
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/ecs/enable_in_transit_encryption_rule.go
+++ b/internal/app/tfsec/rules/aws/ecs/enable_in_transit_encryption_rule.go
@@ -1,9 +1,7 @@
 package ecs
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/ecs"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -57,29 +55,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_task_definition"},
 		Base:           ecs.CheckEnableInTransitEncryption,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("volume") {
-				return
-			}
-
-			volumeBlocks := resourceBlock.GetBlocks("volume")
-			for _, v := range volumeBlocks {
-				if v.MissingChild("efs_volume_configuration") {
-					continue
-				}
-				efsConfigBlock := v.GetBlock("efs_volume_configuration")
-				if efsConfigBlock.MissingChild("transit_encryption") {
-					results.Add("Resource has efs configuration with in transit encryption implicitly disabled", efsConfigBlock)
-					continue
-				}
-				transitAttr := efsConfigBlock.GetAttribute("transit_encryption")
-				if transitAttr.Equals("disabled", block.IgnoreCase) {
-					results.Add("Resource has efs configuration with transit encryption explicitly disabled", transitAttr)
-				}
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/ecs/no_plaintext_secrets_rule.go
+++ b/internal/app/tfsec/rules/aws/ecs/no_plaintext_secrets_rule.go
@@ -1,18 +1,9 @@
 package ecs
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
-
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/ecs"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/debug"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/security"
 	"github.com/aquasecurity/tfsec/pkg/rule"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func init() {
@@ -59,37 +50,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_task_definition"},
 		Base:           ecs.CheckNoPlaintextSecrets,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if definitionsAttr := resourceBlock.GetAttribute("container_definitions"); definitionsAttr.IsNotNil() && definitionsAttr.Type() == cty.String {
-				rawJSON := strings.TrimSpace(definitionsAttr.Value().AsString())
-
-				var definitions []struct {
-					EnvVars []struct {
-						Name  string `json:"name"`
-						Value string `json:"value"`
-					} `json:"environment"`
-				}
-
-				err := json.Unmarshal([]byte(rawJSON), &definitions)
-				if err != nil {
-					debug.Log("an error occurred processing container definition json: %s: %s", resourceBlock.Range(), err.Error())
-					return
-				}
-
-				for _, definition := range definitions {
-					for _, env := range definition.EnvVars {
-						if security.IsSensitiveAttribute(env.Name) && env.Value != "" {
-							results.Add(
-								fmt.Sprintf("Resource includes a potentially sensitive environment variable ('%s') in the container definition.", env.Name),
-								definitionsAttr,
-							)
-						}
-					}
-				}
-			}
-
-			return results
-		},
 	})
 }


### PR DESCRIPTION
- removed `CheckTerraform` from all 3 ECS rules
- added adaption code for ECS
Resolves #1262