### PR TITLE
AWS lambda - convert tfsec checks to use defsec logic

### DIFF
--- a/internal/app/tfsec/adapter/aws/lambda/adapt.go
+++ b/internal/app/tfsec/adapter/aws/lambda/adapt.go
@@ -2,9 +2,59 @@ package lambda
 
 import (
 	"github.com/aquasecurity/defsec/provider/aws/lambda"
+	"github.com/aquasecurity/defsec/types"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) lambda.Lambda {
-	return lambda.Lambda{}
+	return lambda.Lambda{
+		Functions: adaptFunctions(modules),
+	}
+}
+
+func adaptFunctions(modules []block.Module) []lambda.Function {
+	var functions []lambda.Function
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_lambda_function") {
+			functions = append(functions, adaptFunction(resource, modules))
+		}
+	}
+	return functions
+}
+
+func adaptFunction(function block.Block, modules []block.Module) lambda.Function {
+	return lambda.Function{
+		Metadata:    function.Metadata(),
+		Tracing:     adaptTracing(function),
+		Permissions: adaptPermissions(function, modules),
+	}
+}
+
+func adaptTracing(function block.Block) lambda.Tracing {
+	if tracingConfig := function.GetBlock("tracing_config"); tracingConfig.IsNotNil() {
+		return lambda.Tracing{
+			Mode: tracingConfig.GetAttribute("mode").AsStringValueOrDefault("", tracingConfig),
+		}
+	}
+
+	return lambda.Tracing{
+		Mode: types.StringDefault("", function.Metadata()),
+	}
+}
+
+func adaptPermissions(function block.Block, modules []block.Module) []lambda.Permission {
+	var permissions []lambda.Permission
+	for _, module := range modules {
+		for _, permission := range module.GetResourcesByType("aws_lambda_permission") {
+			var functionName = function.GetAttribute("function_name").AsStringValueOrDefault("", function)
+			var permissionFunctionName = permission.GetAttribute("function_name").AsStringValueOrDefault("", permission)
+			if functionName.EqualTo(permissionFunctionName.Value()) {
+				permissions = append(permissions, lambda.Permission{
+					Principal: permission.GetAttribute("principal").AsStringValueOrDefault("", permission),
+					SourceARN: permission.GetAttribute("source_arn").AsStringValueOrDefault("", permission),
+				})
+			}
+		}
+	}
+	return permissions
 }

--- a/internal/app/tfsec/rules/aws/lambda/enable_tracing_rule.go
+++ b/internal/app/tfsec/rules/aws/lambda/enable_tracing_rule.go
@@ -1,9 +1,7 @@
 package lambda
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/lambda"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -94,7 +92,7 @@ func init() {
      }
    }
    tracing_config {
-     mode = "something"
+     mode = "Active"
    }
  }
  `},
@@ -108,15 +106,5 @@ func init() {
 			"aws_lambda_function",
 		},
 		Base: lambda.CheckEnableTracing,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-			if configBlock := resourceBlock.GetBlock("tracing_config"); configBlock.IsNil() {
-				results.Add("Resource uses default value for tracing_config.mode", resourceBlock)
-			} else if modeAttr := configBlock.GetAttribute("mode"); modeAttr.IsNil() {
-				results.Add("Resource uses default value for tracing_config.mode", configBlock)
-			} else if modeAttr.IsEmpty() {
-				results.Add("Resource has tracing_config.mode set to ", modeAttr)
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/lambda/restrict_source_arn_rule.go
+++ b/internal/app/tfsec/rules/aws/lambda/restrict_source_arn_rule.go
@@ -1,9 +1,7 @@
 package lambda
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/lambda"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -34,17 +32,5 @@ resource "aws_lambda_permission" "good_example" {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lambda_permission"},
 		Base:           lambda.CheckRestrictSourceArn,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.HasChild("principal") {
-				if principalAttr := resourceBlock.GetAttribute("principal"); principalAttr.EndsWith("amazonaws.com") {
-					if resourceBlock.MissingChild("source_arn") {
-						results.Add("Resource missing source ARN but has *.amazonaws.com principal.", principalAttr)
-					}
-				}
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/lambda/restrict_source_arn_rule_test.go
+++ b/internal/app/tfsec/rules/aws/lambda/restrict_source_arn_rule_test.go
@@ -18,6 +18,29 @@ func Test_AWSCheckLambdaFunctionForSourceARN(t *testing.T) {
 		{
 			name: "Principal present with no source_arn",
 			source: `
+ resource "aws_lambda_function" "func" {
+   filename      = "lambda_function_payload.zip"
+   function_name = "lambda_function_name"
+   role          = aws_iam_role.iam_for_lambda.arn
+   handler       = "exports.test"
+ 
+   # The filebase64sha256() function is available in Terraform 0.11.12 and later
+   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+   # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
+   source_code_hash = filebase64sha256("lambda_function_payload.zip")
+ 
+   runtime = "nodejs12.x"
+ 
+   environment {
+     variables = {
+       foo = "bar"
+     }
+   }
+   tracing_config {
+     mode = "Active"
+   }
+ }
+
  resource "aws_lambda_permission" "with_sns" {
    statement_id  = "AllowExecutionFromSNS"
    action        = "lambda:InvokeFunction"
@@ -30,6 +53,29 @@ func Test_AWSCheckLambdaFunctionForSourceARN(t *testing.T) {
 		{
 			name: "Principal present and source_arn present",
 			source: `
+ resource "aws_lambda_function" "func" {
+   filename      = "lambda_function_payload.zip"
+   function_name = "lambda_function_name"
+   role          = aws_iam_role.iam_for_lambda.arn
+   handler       = "exports.test"
+ 
+   # The filebase64sha256() function is available in Terraform 0.11.12 and later
+   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+   # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
+   source_code_hash = filebase64sha256("lambda_function_payload.zip")
+ 
+   runtime = "nodejs12.x"
+ 
+   environment {
+     variables = {
+       foo = "bar"
+     }
+   }
+   tracing_config {
+     mode = "Active"
+   }
+ }
+
  resource "aws_lambda_permission" "with_sns" {
    statement_id  = "AllowExecutionFromSNS"
    action        = "lambda:InvokeFunction"
@@ -43,6 +89,29 @@ func Test_AWSCheckLambdaFunctionForSourceARN(t *testing.T) {
 		{
 			name: "No principal specified",
 			source: `
+ resource "aws_lambda_function" "func" {
+   filename      = "lambda_function_payload.zip"
+   function_name = "lambda_function_name"
+   role          = aws_iam_role.iam_for_lambda.arn
+   handler       = "exports.test"
+ 
+   # The filebase64sha256() function is available in Terraform 0.11.12 and later
+   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+   # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
+   source_code_hash = filebase64sha256("lambda_function_payload.zip")
+ 
+   runtime = "nodejs12.x"
+ 
+   environment {
+     variables = {
+       foo = "bar"
+     }
+   }
+   tracing_config {
+     mode = "Active"
+   }
+ }
+
  resource "aws_lambda_permission" "with_sns" {
    statement_id  = "AllowExecutionFromSNS"
    action        = "lambda:InvokeFunction"


### PR DESCRIPTION
- removed `CheckTerraform` from all 2 lambda rules
- added adaption code for lambda
- modified `restrict_source_arn_rule_test` (adding in the lambda functions for the permission resources to target)

Resolves #1282