### PR TITLE
AWS CloudFront - adapt to use defsec

### DIFF
--- a/internal/app/tfsec/adapter/aws/cloudfront/adapt.go
+++ b/internal/app/tfsec/adapter/aws/cloudfront/adapt.go
@@ -2,9 +2,78 @@ package cloudfront
 
 import (
 	"github.com/aquasecurity/defsec/provider/aws/cloudfront"
+	"github.com/aquasecurity/defsec/types"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) cloudfront.Cloudfront {
-	return cloudfront.Cloudfront{}
+	return cloudfront.Cloudfront{
+		Distributions: adaptDistributions(modules),
+	}
+}
+
+func adaptDistributions(modules []block.Module) []cloudfront.Distribution {
+	var distributions []cloudfront.Distribution
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_cloudfront_distribution") {
+			distributions = append(distributions, adaptDistribution(resource))
+		}
+	}
+	return distributions
+}
+
+func adaptDistribution(resource block.Block) cloudfront.Distribution {
+	WAFIDAtrr := resource.GetAttribute("web_acl_id")
+	WAFIDAVal := WAFIDAtrr.AsStringValueOrDefault("", resource)
+
+	defaultCacheBehaviour := cloudfront.CacheBehaviour{
+		Metadata:             *resource.GetMetadata(),
+		ViewerProtocolPolicy: types.String("allow-all", *resource.GetMetadata()),
+	}
+	var orderedCacheBehaviours []cloudfront.CacheBehaviour
+
+	bucketVal := types.String("", *resource.GetMetadata())
+	if resource.HasChild("logging_config") {
+		loggingBlock := resource.GetBlock("logging_config")
+		bucketAttr := loggingBlock.GetAttribute("bucket")
+		bucketVal = bucketAttr.AsStringValueOrDefault("", loggingBlock)
+	}
+
+	if resource.HasChild("default_cache_behavior") {
+		defaultCacheBlock := resource.GetBlock("default_cache_behavior")
+		defaultCacheBehaviour.Metadata = *defaultCacheBlock.GetMetadata()
+		ViewerProtocolPolicyAttr := defaultCacheBlock.GetAttribute("viewer_protocol_policy")
+		defaultCacheBehaviour.ViewerProtocolPolicy = ViewerProtocolPolicyAttr.AsStringValueOrDefault("allow-all", defaultCacheBlock)
+	}
+
+	orderedCacheBlocks := resource.GetBlocks("ordered_cache_behavior")
+	for _, orderedCacheBlock := range orderedCacheBlocks {
+		ViewerProtocolPolicyAttr := orderedCacheBlock.GetAttribute("viewer_protocol_policy")
+		ViewerProtocolPolicyVal := ViewerProtocolPolicyAttr.AsStringValueOrDefault("allow-all", orderedCacheBlock)
+
+		orderedCacheBehaviours = append(orderedCacheBehaviours, cloudfront.CacheBehaviour{
+			Metadata:             *orderedCacheBlock.GetMetadata(),
+			ViewerProtocolPolicy: ViewerProtocolPolicyVal,
+		})
+	}
+
+	minProtocolVal := types.String("", *resource.GetMetadata())
+	if resource.HasChild("viewer_certificate") {
+		viewerCertBlock := resource.GetBlock("viewer_certificate")
+		minProtocolAttr := viewerCertBlock.GetAttribute("minimum_protocol_version")
+		minProtocolVal = minProtocolAttr.AsStringValueOrDefault("TLSv1", viewerCertBlock)
+	}
+
+	return cloudfront.Distribution{
+		Metadata: *resource.GetMetadata(),
+		WAFID:    WAFIDAVal,
+		Logging: cloudfront.Logging{
+			Bucket: bucketVal,
+		},
+		DefaultCacheBehaviour:  defaultCacheBehaviour,
+		OrdererCacheBehaviours: orderedCacheBehaviours,
+		ViewerCertificate: cloudfront.ViewerCertificate{
+			MinimumProtocolVersion: minProtocolVal,
+		},
+	}
 }

--- a/internal/app/tfsec/rules/aws/cloudfront/enable_logging_rule.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/enable_logging_rule.go
@@ -1,9 +1,7 @@
 package cloudfront
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/cloudfront"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -33,11 +31,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		Base:           cloudfront.CheckEnableLogging,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-			if resourceBlock.MissingChild("logging_config") {
-				results.Add("Resource does not have Access Logging configured", resourceBlock)
-			}
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/cloudfront/enable_logging_rule_test.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/enable_logging_rule_test.go
@@ -31,6 +31,7 @@ func Test_AWSCloudfrontDistributionAccessLoggingEnabled(t *testing.T) {
  resource "aws_cloudfront_distribution" "good_example" {
  	// other config
  	logging_config {
+		 bucket = "mylogs.s3.amazonaws.com"
  	}
  }
  `,

--- a/internal/app/tfsec/rules/aws/cloudfront/enable_waf_rule.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/enable_waf_rule.go
@@ -1,9 +1,7 @@
 package cloudfront
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/cloudfront"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -82,14 +80,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		Base:           cloudfront.CheckEnableWaf,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			wafAclIdBlock := resourceBlock.GetAttribute("web_acl_id")
-			if wafAclIdBlock.IsNil() {
-				results.Add("Resource does not have a WAF in front of it.", resourceBlock)
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/cloudfront/enforce_https_rule.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/enforce_https_rule.go
@@ -1,9 +1,7 @@
 package cloudfront
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/cloudfront"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -31,35 +29,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		Base:           cloudfront.CheckEnforceHttps,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			defaultBehaviorBlock := resourceBlock.GetBlock("default_cache_behavior")
-			if defaultBehaviorBlock.IsNil() {
-				results.Add("Resource defines a CloudFront distribution that allows unencrypted communications (missing default_cache_behavior block).", resourceBlock)
-				return
-			}
-
-			protocolPolicyAttr := defaultBehaviorBlock.GetAttribute("viewer_protocol_policy")
-			if protocolPolicyAttr.IsNil() {
-				results.Add("Resource defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", defaultBehaviorBlock)
-				return
-			}
-			if protocolPolicyAttr.Equals("allow-all") {
-				results.Add("Resource defines a CloudFront distribution that allows unencrypted communications.", protocolPolicyAttr)
-				return
-			}
-
-			orderedBehaviorBlocks := resourceBlock.GetBlocks("ordered_cache_behavior")
-			for _, orderedBehaviorBlock := range orderedBehaviorBlocks {
-				orderedProtocolPolicyAttr := orderedBehaviorBlock.GetAttribute("viewer_protocol_policy")
-				if orderedProtocolPolicyAttr.IsNil() {
-					results.Add("Resource defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", orderedBehaviorBlock)
-				} else if orderedProtocolPolicyAttr.Equals("allow-all") {
-					results.Add("Resource defines a CloudFront distribution that allows unencrypted communications.", orderedProtocolPolicyAttr)
-				}
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule.go
+++ b/internal/app/tfsec/rules/aws/cloudfront/use_secure_tls_policy_rule.go
@@ -1,9 +1,7 @@
 package cloudfront
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/cloudfront"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -33,24 +31,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		Base:           cloudfront.CheckUseSecureTlsPolicy,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			viewerCertificateBlock := resourceBlock.GetBlock("viewer_certificate")
-			if viewerCertificateBlock.IsNil() {
-				results.Add("Resource defines outdated SSL/TLS policies (missing viewer_certificate block)", resourceBlock)
-				return
-			}
-
-			minVersionAttr := viewerCertificateBlock.GetAttribute("minimum_protocol_version")
-			if minVersionAttr.IsNil() {
-				results.Add("Resource defines outdated SSL/TLS policies (missing minimum_protocol_version attribute)", viewerCertificateBlock)
-				return
-			}
-
-			if minVersionAttr.NotEqual("TLSv1.2_2021") {
-				results.Add("Resource defines outdated SSL/TLS policies (not using TLSv1.2_2021)", minVersionAttr)
-			}
-			return results
-		},
 	})
 }


### PR DESCRIPTION
Write adapt functions

Add required `bucket` attribute to `logging` block in test (defsec checks this attribute's presence to determine whether logging is enabled).

Note: defsec only alerts when `viewer_protocol_policy` equals `allow_all`. As such in cases when the attribute is missing, `allow_all` is considered the default value even though it is not explicitly established as the default by Terraform. 
Closes #1284 