### PR TITLE
AWS SNS - convert tfsec checks to use defsec logic

### DIFF
--- a/internal/app/tfsec/adapter/aws/sns/adapt.go
+++ b/internal/app/tfsec/adapter/aws/sns/adapt.go
@@ -6,5 +6,30 @@ import (
 )
 
 func Adapt(modules []block.Module) sns.SNS {
-	return sns.SNS{}
+	return sns.SNS{
+		Topics: adaptTopics(modules),
+	}
+}
+
+func adaptTopics(modules []block.Module) []sns.Topic {
+	var topics []sns.Topic
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_sns_topic") {
+			topics = append(topics, adaptTopic(resource))
+		}
+	}
+	return topics
+}
+
+func adaptTopic(resourceBlock block.Block) sns.Topic {
+	return sns.Topic{
+		Metadata: resourceBlock.Metadata(),
+		Encryption: adaptEncryption(resourceBlock),
+	}
+}
+
+func adaptEncryption(resourceBlock block.Block) sns.Encryption {
+	return sns.Encryption{
+		KMSKeyID: resourceBlock.GetAttribute("kms_master_key_id").AsStringValueOrDefault("alias/aws/sns", resourceBlock),
+	}
 }

--- a/internal/app/tfsec/rules/aws/sns/enable_topic_encryption_rule.go
+++ b/internal/app/tfsec/rules/aws/sns/enable_topic_encryption_rule.go
@@ -1,12 +1,9 @@
 package sns
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/sns"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func init() {
@@ -28,32 +25,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sns_topic"},
 		Base:           sns.CheckEnableTopicEncryption,
-		CheckTerraform: func(resourceBlock block.Block, module block.Module) (results rules.Results) {
-
-			kmsKeyIDAttr := resourceBlock.GetAttribute("kms_master_key_id")
-			if kmsKeyIDAttr.IsNil() {
-				results.Add("Resource defines an unencrypted SNS topic.", resourceBlock)
-				return
-			} else if kmsKeyIDAttr.Type() == cty.String && kmsKeyIDAttr.Value().AsString() == "" {
-				results.Add("Resource defines an unencrypted SNS topic.", kmsKeyIDAttr)
-				return
-			}
-
-			if kmsKeyIDAttr.IsDataBlockReference() {
-
-				kmsData, err := module.GetReferencedBlock(kmsKeyIDAttr, resourceBlock)
-				if err != nil {
-					return
-				}
-
-				keyIdAttr := kmsData.GetAttribute("key_id")
-				if keyIdAttr.IsNotNil() && keyIdAttr.Equals("alias/aws/sns") {
-					results.Add("Resource explicitly uses the default CMK", keyIdAttr)
-				}
-
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/sns/enable_topic_encryption_rule_test.go
+++ b/internal/app/tfsec/rules/aws/sns/enable_topic_encryption_rule_test.go
@@ -26,13 +26,9 @@ func Test_AWSUnencryptedSNSTopic(t *testing.T) {
 		{
 			name: "check with default encryption key id specified for aws_sns_topic fails check",
 			source: `
- data "aws_kms_key" "by_alias" {
-   key_id = "alias/aws/sns"
- }
- 
  resource "aws_sns_topic" "test" {
    name              = "sns_ecnrypted"
-   kms_master_key_id = data.aws_kms_key.by_alias.arn
+   kms_master_key_id = "alias/aws/sns"
  }`,
 			mustIncludeResultCode: expectedCode,
 		},


### PR DESCRIPTION
Resolves #1291
Fixed test "check with default encryption key id specified for aws_sns_topic fails check" as aws_kms_key does not accept key_id as an argument