### PR TITLE
AWS Athena - adapt to use defsec

### DIFF
--- a/internal/app/tfsec/adapter/aws/athena/adapt.go
+++ b/internal/app/tfsec/adapter/aws/athena/adapt.go
@@ -1,10 +1,89 @@
 package athena
 
 import (
+	"github.com/aquasecurity/defsec/types"
+
 	"github.com/aquasecurity/defsec/provider/aws/athena"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 func Adapt(modules []block.Module) athena.Athena {
-	return athena.Athena{}
+	return athena.Athena{
+		Databases:  adaptDatabases(modules),
+		Workgroups: adaptWorkgroups(modules),
+	}
+}
+
+func adaptDatabases(modules []block.Module) []athena.Database {
+	var databases []athena.Database
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_athena_database") {
+			databases = append(databases, adaptDatabase(resource))
+		}
+	}
+	return databases
+}
+
+func adaptWorkgroups(modules []block.Module) []athena.Workgroup {
+	var workgroups []athena.Workgroup
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_athena_workgroup") {
+			workgroups = append(workgroups, adaptWorkgroup(resource))
+		}
+	}
+	return workgroups
+}
+
+func adaptDatabase(resource block.Block) athena.Database {
+	nameAttr := resource.GetAttribute("name")
+	nameVal := nameAttr.AsStringValueOrDefault("", resource)
+
+	encryptionOptionVal := types.StringDefault("", *resource.GetMetadata())
+
+	if resource.HasChild("encryption_configuration") {
+		encryptionConfigBlock := resource.GetBlock("encryption_configuration")
+		encryptionOptionAttr := encryptionConfigBlock.GetAttribute("encryption_option")
+		encryptionOptionVal = encryptionOptionAttr.AsStringValueOrDefault("", encryptionConfigBlock)
+	}
+
+	return athena.Database{
+		Metadata: *resource.GetMetadata(),
+		Name:     nameVal,
+		Encryption: athena.EncryptionConfiguration{
+			Type: encryptionOptionVal,
+		},
+	}
+}
+
+func adaptWorkgroup(resource block.Block) athena.Workgroup {
+	nameAttr := resource.GetAttribute("name")
+	nameVal := nameAttr.AsStringValueOrDefault("", resource)
+
+	enforceWGConfigVal := types.BoolDefault(false, *resource.GetMetadata())
+	encryptionOptionVal := types.StringDefault("", *resource.GetMetadata())
+
+	if resource.HasChild("configuration") {
+		configBlock := resource.GetBlock("configuration")
+
+		enforceWGConfigAttr := configBlock.GetAttribute("enforce_workgroup_configuration")
+		enforceWGConfigVal = enforceWGConfigAttr.AsBoolValueOrDefault(true, configBlock)
+
+		if configBlock.HasChild("result_configuration") {
+			resultConfigBlock := configBlock.GetBlock("result_configuration")
+			if resultConfigBlock.HasChild("encryption_configuration") {
+				encryptionConfigBlock := resultConfigBlock.GetBlock("encryption_configuration")
+				encryptionOptionAttr := encryptionConfigBlock.GetAttribute("encryption_option")
+				encryptionOptionVal = encryptionOptionAttr.AsStringValueOrDefault("", encryptionConfigBlock)
+			}
+		}
+	}
+
+	return athena.Workgroup{
+		Metadata: *resource.GetMetadata(),
+		Name:     nameVal,
+		Encryption: athena.EncryptionConfiguration{
+			Type: encryptionOptionVal,
+		},
+		EnforceConfiguration: enforceWGConfigVal,
+	}
 }

--- a/internal/app/tfsec/rules/aws/athena/enable_at_rest_encryption_rule.go
+++ b/internal/app/tfsec/rules/aws/athena/enable_at_rest_encryption_rule.go
@@ -1,11 +1,7 @@
 package athena
 
 import (
-	"strings"
-
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/athena"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -68,24 +64,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_athena_database", "aws_athena_workgroup"},
 		Base:           athena.CheckEnableAtRestEncryption,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if strings.EqualFold(resourceBlock.TypeLabel(), "aws_athena_workgroup") {
-				if !resourceBlock.HasChild("configuration") {
-					return
-				}
-				configBlock := resourceBlock.GetBlock("configuration")
-				if !configBlock.HasChild("result_configuration") {
-					return
-				}
-				resourceBlock = configBlock.GetBlock("result_configuration")
-			}
-
-			if resourceBlock.MissingChild("encryption_configuration") {
-				results.Add("Missing encryption configuration block.", resourceBlock)
-			}
-
-			return results
-		},
 	})
 }

--- a/internal/app/tfsec/rules/aws/athena/enable_at_rest_encryption_rule_test.go
+++ b/internal/app/tfsec/rules/aws/athena/enable_at_rest_encryption_rule_test.go
@@ -93,7 +93,7 @@ func Test_AWSEnsureAthenaDbEncrypted(t *testing.T) {
    }
  }
  `,
-			mustExcludeResultCode: expectedCode,
+			mustIncludeResultCode: expectedCode,
 		},
 	}
 

--- a/internal/app/tfsec/rules/aws/athena/no_encryption_override_rule.go
+++ b/internal/app/tfsec/rules/aws/athena/no_encryption_override_rule.go
@@ -1,9 +1,7 @@
 package athena
 
 import (
-	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/rules/aws/athena"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 	"github.com/aquasecurity/tfsec/internal/app/tfsec/scanner"
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
@@ -60,27 +58,5 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_athena_workgroup"},
 		Base:           athena.CheckNoEncryptionOverride,
-		CheckTerraform: func(resourceBlock block.Block, _ block.Module) (results rules.Results) {
-
-			if resourceBlock.MissingChild("configuration") {
-				results.Add("Resource is missing the configuration block.", resourceBlock)
-				return
-			}
-
-			configBlock := resourceBlock.GetBlock("configuration")
-
-			configBlock.HasChild("enforce_workgroup_configuration")
-			enforceWorkgroupConfigAttr := configBlock.GetAttribute("enforce_workgroup_configuration")
-
-			if enforceWorkgroupConfigAttr.IsNil() {
-				return
-			}
-
-			if enforceWorkgroupConfigAttr.IsFalse() {
-				results.Add("Resource has enforce_workgroup_configuration set to false.", enforceWorkgroupConfigAttr)
-			}
-
-			return results
-		},
 	})
 }


### PR DESCRIPTION
Create adapter.

Update test to expect alert when `result_configuration` block is missing. 

Closes #1260 