### PR TITLE
add optional "assignVariable" attribute to "matchSpec"

### DIFF
--- a/docs/getting-started/configuration/custom-checks.md
+++ b/docs/getting-started/configuration/custom-checks.md
@@ -98,14 +98,15 @@ The check contains up of the following attributes;
 
 The `MatchSpec` is the what will define the check itself - this is fairly basic and is made up of the following attributes
 
-| Attribute          | Description                                                                                        |
-| :----------------- | :------------------------------------------------------------------------------------------------- |
-| name               | The name of the attribute or block to run the check on                                             |
-| action             | The check type - see below for more information                                                    |
-| value              | In cases where a value is required, the value to look for                                          |
-| ignoreUndefined    | If the attribute is undefined, ignore and pass the check                                           |
-| subMatch           | A sub MatchSpec block for nested checking - think looking for `enabled` value in a `logging` block |
-| predicateMatchSpec | An array of MatchSpec blocks to be logically aggregated by either `and` or `or` actions            |
+| Attribute          | Description                                                                                                                             |
+| :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| name               | The name of the attribute or block to run the check on                                                                                  |
+| action             | The check type - see below for more information                                                                                         |
+| value              | In cases where a value is required, the value to look for, text matching `TFSEC_VAR_{VAR_NAME}` will be replace with the variable value |
+| ignoreUndefined    | If the attribute is undefined, ignore and pass the check                                                                                |
+| subMatch           | A sub MatchSpec block for nested checking - think looking for `enabled` value in a `logging` block                                      |
+| predicateMatchSpec | An array of MatchSpec blocks to be logically aggregated by either `and` or `or` actions                                                 |
+| assignVariable     | The name of the "variable" to store the value of the `name` attribute in, has to by uppercase and start with `TFSEC_VAR_`               |
 
 #### Check Actions
 There are a number of `CheckActions` available which should allow you to quickly put together most checks.

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -112,6 +112,7 @@ type MatchSpec struct {
 	SubMatch           *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
 	IgnoreUndefined    bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
 	IgnoreUnmatched    bool        `json:"ignoreUnmatched,omitempty" yaml:"ignoreUnmatched,omitempty"`
+	AssignVariable     string      `json:"assignVariable,omitempty" yaml:"assignVariable,omitempty"`
 }
 
 // Check specifies the check definition represented in json/yaml

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -2,10 +2,23 @@ package custom
 
 import (
 	"github.com/aquasecurity/defsec/severity"
+	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 type MatchType string
 type CheckAction string
+
+type customCheckContext struct {
+	module    block.Module
+	variables map[string]string
+}
+
+func NewCustomCheckContext(module block.Module) *customCheckContext {
+	return &customCheckContext{
+		module:    module,
+		variables: make(map[string]string),
+	}
+}
 
 var ValidCheckActions = []CheckAction{
 	InModule,

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -2,23 +2,10 @@ package custom
 
 import (
 	"github.com/aquasecurity/defsec/severity"
-	"github.com/aquasecurity/tfsec/internal/app/tfsec/block"
 )
 
 type MatchType string
 type CheckAction string
-
-type customCheckContext struct {
-	module    block.Module
-	variables map[string]string
-}
-
-func NewCustomCheckContext(module block.Module) *customCheckContext {
-	return &customCheckContext{
-		module:    module,
-		variables: make(map[string]string),
-	}
-}
 
 var ValidCheckActions = []CheckAction{
 	InModule,

--- a/internal/app/tfsec/custom/custom_context.go
+++ b/internal/app/tfsec/custom/custom_context.go
@@ -1,0 +1,31 @@
+package custom
+
+import "github.com/aquasecurity/tfsec/internal/app/tfsec/block"
+
+type customCheckVariables map[string]string
+
+type customContext struct {
+	module    block.Module
+	variables customCheckVariables
+}
+
+func NewEmptyCustomContext() *customContext {
+	return &customContext{
+		module:    nil,
+		variables: make(customCheckVariables),
+	}
+}
+
+func NewCustomContext(module block.Module) *customContext {
+	return &customContext{
+		module:    module,
+		variables: make(customCheckVariables),
+	}
+}
+
+func NewCustomContextWithVariables(module block.Module, variables customCheckVariables) *customContext {
+	return &customContext{
+		module:    module,
+		variables: variables,
+	}
+}

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/aquasecurity/defsec/provider"
 	"github.com/aquasecurity/defsec/rules"
@@ -11,12 +12,14 @@ import (
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
 
-var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, block.Module) bool{
-	IsPresent: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, map[string]string) bool{
+	IsPresent: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		return block.HasChild(spec.Name) || spec.IgnoreUndefined
 	},
-	NotPresent: func(block block.Block, spec *MatchSpec, module block.Module) bool { return !block.HasChild(spec.Name) },
-	IsEmpty: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	NotPresent: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
+		return !block.HasChild(spec.Name)
+	},
+	IsEmpty: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		if block.MissingChild(spec.Name) {
 			return true
 		}
@@ -28,93 +31,93 @@ var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, block.Module)
 		childBlock := block.GetBlock(spec.Name)
 		return childBlock.IsEmpty()
 	},
-	StartsWith: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	StartsWith: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.StartsWith(spec.MatchValue)
+		return attribute.StartsWith(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	EndsWith: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	EndsWith: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.EndsWith(spec.MatchValue)
+		return attribute.EndsWith(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	Contains: func(b block.Block, spec *MatchSpec, module block.Module) bool {
+	Contains: func(b block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := b.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.Contains(spec.MatchValue, block.IgnoreCase)
+		return attribute.Contains(processMatchValueVariables(spec.MatchValue, variables), block.IgnoreCase)
 	},
-	NotContains: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	NotContains: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return !attribute.Contains(spec.MatchValue)
+		return !attribute.Contains(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	Equals: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	Equals: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.Equals(spec.MatchValue)
+		return attribute.Equals(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	NotEqual: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	NotEqual: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.NotEqual(spec.MatchValue)
+		return attribute.NotEqual(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	LessThan: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	LessThan: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.LessThan(spec.MatchValue)
+		return attribute.LessThan(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	LessThanOrEqualTo: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	LessThanOrEqualTo: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.LessThanOrEqualTo(spec.MatchValue)
+		return attribute.LessThanOrEqualTo(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	GreaterThan: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	GreaterThan: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.GreaterThan(spec.MatchValue)
+		return attribute.GreaterThan(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	GreaterThanOrEqualTo: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	GreaterThanOrEqualTo: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.GreaterThanOrEqualTo(spec.MatchValue)
+		return attribute.GreaterThanOrEqualTo(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	RegexMatches: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	RegexMatches: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.RegexMatches(spec.MatchValue)
+		return attribute.RegexMatches(processMatchValueVariables(spec.MatchValue, variables))
 	},
-	IsAny: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	IsAny: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
-		return attribute != nil && attribute.IsAny(unpackInterfaceToInterfaceSlice(spec.MatchValue)...)
+		return attribute != nil && attribute.IsAny(unpackInterfaceToInterfaceSlice(processMatchValueVariables(spec.MatchValue, variables))...)
 	},
-	IsNone: func(block block.Block, spec *MatchSpec, module block.Module) bool {
+	IsNone: func(block block.Block, spec *MatchSpec, variables map[string]string) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
-		return attribute.IsNone(unpackInterfaceToInterfaceSlice(spec.MatchValue)...)
+		return attribute.IsNone(unpackInterfaceToInterfaceSlice(processMatchValueVariables(spec.MatchValue, variables))...)
 	},
 	RequiresPresence: func(block block.Block, spec *MatchSpec, module block.Module) bool { return resourceFound(spec, module) },
 }
@@ -143,7 +146,7 @@ func processFoundChecks(checks ChecksFile) {
 				RequiredSources: customCheck.RequiredSources,
 				CheckTerraform: func(rootBlock block.Block, module block.Module) (results rules.Results) {
 					matchSpec := customCheck.MatchSpec
-					if !evalMatchSpec(rootBlock, matchSpec, module) {
+					if !evalMatchSpec(rootBlock, matchSpec, module, nil) {
 						results.Add(
 							fmt.Sprintf("Custom check failed for resource %s. %s", rootBlock.FullName(), customCheck.ErrorMessage),
 							rootBlock,
@@ -156,7 +159,10 @@ func processFoundChecks(checks ChecksFile) {
 	}
 }
 
-func evalMatchSpec(b block.Block, spec *MatchSpec, module block.Module) bool {
+func evalMatchSpec(b block.Block, spec *MatchSpec, module block.Module, variables map[string]string) bool {
+	if variables == nil {
+		variables = make(map[string]string)
+	}
 	if b.IsNil() {
 		return false
 	}
@@ -164,7 +170,7 @@ func evalMatchSpec(b block.Block, spec *MatchSpec, module block.Module) bool {
 
 	for _, preCondition := range spec.PreConditions {
 		clone := preCondition
-		if !evalMatchSpec(b, &clone, module) {
+		if !evalMatchSpec(b, &clone, module, variables) {
 			// precondition not met
 			return true
 		}
@@ -174,7 +180,7 @@ func evalMatchSpec(b block.Block, spec *MatchSpec, module block.Module) bool {
 	case InModule:
 		return b.InModule()
 	case RegexMatches:
-		if !matchFunctions[RegexMatches](b, spec, module) {
+		if !matchFunctions[RegexMatches](b, spec, variables) {
 			return spec.IgnoreUnmatched
 		}
 		evalResult = true
@@ -183,42 +189,46 @@ func evalMatchSpec(b block.Block, spec *MatchSpec, module block.Module) bool {
 	case OfType:
 		return ofType(b, spec)
 	case Not:
-		return notifyPredicate(b, spec, module)
+		return notifyPredicate(b, spec, module, variables)
 	case And:
-		return processAndPredicate(spec, b, module)
+		return processAndPredicate(spec, b, module, variables)
 	case Or:
-		return processOrPredicate(spec, b, module)
+		return processOrPredicate(spec, b, module, variables)
 	default:
-		evalResult = matchFunctions[spec.Action](b, spec, module)
+		evalResult = matchFunctions[spec.Action](b, spec, variables)
+	}
+
+	if len(spec.AssignVariable) > 0 {
+		variables[spec.AssignVariable] = b.GetAttribute(spec.Name).AsStringValueOrDefault("", b).Value()
 	}
 
 	if spec.SubMatch != nil {
-		evalResult = processSubMatches(spec, b, module, evalResult)
+		evalResult = processSubMatches(spec, b, module, variables, evalResult)
 	}
 
 	return evalResult
 }
 
-func notifyPredicate(b block.Block, spec *MatchSpec, module block.Module) bool {
-	return !evalMatchSpec(b, &spec.PredicateMatchSpec[0], module)
+func notifyPredicate(b block.Block, spec *MatchSpec, module block.Module, variables map[string]string) bool {
+	return !evalMatchSpec(b, &spec.PredicateMatchSpec[0], module, variables)
 }
 
-func processOrPredicate(spec *MatchSpec, b block.Block, module block.Module) bool {
+func processOrPredicate(spec *MatchSpec, b block.Block, module block.Module, variables map[string]string) bool {
 	for _, childSpec := range spec.PredicateMatchSpec {
 		clone := childSpec
-		if evalMatchSpec(b, &clone, module) {
+		if evalMatchSpec(b, &clone, module, variables) {
 			return true
 		}
 	}
 	return false
 }
 
-func processAndPredicate(spec *MatchSpec, b block.Block, module block.Module) bool {
+func processAndPredicate(spec *MatchSpec, b block.Block, module block.Module, variables map[string]string) bool {
 	set := make(map[bool]bool)
 
 	for _, childSpec := range spec.PredicateMatchSpec {
 		clone := childSpec
-		result := evalMatchSpec(b, &clone, module)
+		result := evalMatchSpec(b, &clone, module, variables)
 		set[result] = true
 
 	}
@@ -226,22 +236,28 @@ func processAndPredicate(spec *MatchSpec, b block.Block, module block.Module) bo
 	return len(set) == 1 && set[true]
 }
 
-func processSubMatches(spec *MatchSpec, b block.Block, module block.Module, evalResult bool) bool {
-	var subMatchTargets []block.Block
-	switch spec.Action {
-	case RequiresPresence:
-		subMatchTargets = module.GetResourcesByType(spec.Name)
-	default:
-		subMatchTargets = b.GetBlocks(spec.Name)
-	}
-	for _, b := range subMatchTargets {
-		evalResult = evalMatchSpec(b, spec.SubMatch, nil)
+func processSubMatches(spec *MatchSpec, b block.Block, module block.Module, variables map[string]string, evalResult bool) bool {
+	for _, b := range b.GetBlocks(spec.Name) {
+		evalResult = evalMatchSpec(b, spec.SubMatch, nil, variables)
 		if !evalResult {
 			break
 		}
 	}
 
 	return evalResult
+}
+
+func processMatchValueVariables(matchValue interface{}, variables map[string]string) interface{} {
+	switch matchValue.(type) {
+	case string:
+		matchValueString := fmt.Sprintf("%v", matchValue)
+		re := regexp.MustCompile(`TFSEC_VAR_[A-Z_]+`)
+		return re.ReplaceAllStringFunc(matchValueString, func(match string) string {
+			return variables[match]
+		})
+	default:
+		return matchValue
+	}
 }
 
 func resourceFound(spec *MatchSpec, module block.Module) bool {

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -12,14 +12,14 @@ import (
 	"github.com/aquasecurity/tfsec/pkg/rule"
 )
 
-var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, *customCheckContext) bool{
-	IsPresent: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, *customContext) bool{
+	IsPresent: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		return block.HasChild(spec.Name) || spec.IgnoreUndefined
 	},
-	NotPresent: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	NotPresent: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		return !block.HasChild(spec.Name)
 	},
-	IsEmpty: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	IsEmpty: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		if block.MissingChild(spec.Name) {
 			return true
 		}
@@ -31,95 +31,95 @@ var matchFunctions = map[CheckAction]func(block.Block, *MatchSpec, *customCheckC
 		childBlock := block.GetBlock(spec.Name)
 		return childBlock.IsEmpty()
 	},
-	StartsWith: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	StartsWith: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.StartsWith(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	EndsWith: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	EndsWith: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.EndsWith(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	Contains: func(b block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	Contains: func(b block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := b.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.Contains(processMatchValueVariables(spec.MatchValue, customCtx.variables), block.IgnoreCase)
 	},
-	NotContains: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	NotContains: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return !attribute.Contains(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	Equals: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	Equals: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.Equals(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	NotEqual: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	NotEqual: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.NotEqual(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	LessThan: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	LessThan: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.LessThan(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	LessThanOrEqualTo: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	LessThanOrEqualTo: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.LessThanOrEqualTo(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	GreaterThan: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	GreaterThan: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.GreaterThan(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	GreaterThanOrEqualTo: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	GreaterThanOrEqualTo: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.GreaterThanOrEqualTo(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	RegexMatches: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	RegexMatches: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.RegexMatches(processMatchValueVariables(spec.MatchValue, customCtx.variables))
 	},
-	IsAny: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	IsAny: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		return attribute != nil && attribute.IsAny(unpackInterfaceToInterfaceSlice(processMatchValueVariables(spec.MatchValue, customCtx.variables))...)
 	},
-	IsNone: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	IsNone: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		attribute := block.GetAttribute(spec.Name)
 		if attribute.IsNil() {
 			return spec.IgnoreUndefined
 		}
 		return attribute.IsNone(unpackInterfaceToInterfaceSlice(processMatchValueVariables(spec.MatchValue, customCtx.variables))...)
 	},
-	RequiresPresence: func(block block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+	RequiresPresence: func(block block.Block, spec *MatchSpec, customCtx *customContext) bool {
 		return resourceFound(spec, customCtx.module)
 	},
 }
@@ -148,7 +148,7 @@ func processFoundChecks(checks ChecksFile) {
 				RequiredSources: customCheck.RequiredSources,
 				CheckTerraform: func(rootBlock block.Block, module block.Module) (results rules.Results) {
 					matchSpec := customCheck.MatchSpec
-					if !evalMatchSpec(rootBlock, matchSpec, NewCustomCheckContext(module)) {
+					if !evalMatchSpec(rootBlock, matchSpec, NewCustomContext(module)) {
 						results.Add(
 							fmt.Sprintf("Custom check failed for resource %s. %s", rootBlock.FullName(), customCheck.ErrorMessage),
 							rootBlock,
@@ -161,7 +161,7 @@ func processFoundChecks(checks ChecksFile) {
 	}
 }
 
-func evalMatchSpec(b block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+func evalMatchSpec(b block.Block, spec *MatchSpec, customCtx *customContext) bool {
 	if b.IsNil() {
 		return false
 	}
@@ -208,11 +208,11 @@ func evalMatchSpec(b block.Block, spec *MatchSpec, customCtx *customCheckContext
 	return evalResult
 }
 
-func notifyPredicate(b block.Block, spec *MatchSpec, customCtx *customCheckContext) bool {
+func notifyPredicate(b block.Block, spec *MatchSpec, customCtx *customContext) bool {
 	return !evalMatchSpec(b, &spec.PredicateMatchSpec[0], customCtx)
 }
 
-func processOrPredicate(spec *MatchSpec, b block.Block, customCtx *customCheckContext) bool {
+func processOrPredicate(spec *MatchSpec, b block.Block, customCtx *customContext) bool {
 	for _, childSpec := range spec.PredicateMatchSpec {
 		clone := childSpec
 		if evalMatchSpec(b, &clone, customCtx) {
@@ -222,7 +222,7 @@ func processOrPredicate(spec *MatchSpec, b block.Block, customCtx *customCheckCo
 	return false
 }
 
-func processAndPredicate(spec *MatchSpec, b block.Block, customCtx *customCheckContext) bool {
+func processAndPredicate(spec *MatchSpec, b block.Block, customCtx *customContext) bool {
 	set := make(map[bool]bool)
 
 	for _, childSpec := range spec.PredicateMatchSpec {
@@ -235,7 +235,7 @@ func processAndPredicate(spec *MatchSpec, b block.Block, customCtx *customCheckC
 	return len(set) == 1 && set[true]
 }
 
-func processSubMatches(spec *MatchSpec, b block.Block, customCtx *customCheckContext, evalResult bool) bool {
+func processSubMatches(spec *MatchSpec, b block.Block, customCtx *customContext, evalResult bool) bool {
 	var subMatchTargets []block.Block
 	switch spec.Action {
 	case RequiresPresence:

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -239,7 +239,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "`Or` match function evaluating incorrectly.")
 		})
 	}
@@ -286,7 +286,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "`And` match function evaluating incorrectly.")
 		})
 	}
@@ -337,7 +337,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "Nested match functions evaluating incorrectly.")
 		})
 	}
@@ -364,7 +364,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "Not match functions evaluating incorrectly.")
 		})
 	}
@@ -414,7 +414,7 @@ resource "aws_ami" "testing" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "precondition functions evaluating incorrectly.")
 		})
 	}
@@ -460,7 +460,7 @@ resource "aws_s3_bucket" "test-bucket" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, nil, nil)
+			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, test.expected, result, "processing variable assignments incorrectly.")
 		})
 	}

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -126,8 +126,8 @@ var testAssignVariableMatchSpec = MatchSpec{
 	Action: "and",
 	PredicateMatchSpec: []MatchSpec{
 		{
-			Name:   "bucket",
-			Action: "isPresent",
+			Name:           "bucket",
+			Action:         "isPresent",
 			AssignVariable: "TFSEC_VAR_BUCKET_NAME",
 		},
 		{

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -528,7 +528,7 @@ resource "google_compute_instance" "default" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, nil)
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
 			assert.Equal(t, result, test.expected, "`regexMatches` match function evaluating incorrectly.")
 		})
 	}

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -239,7 +239,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "`Or` match function evaluating incorrectly.")
 		})
 	}
@@ -286,7 +286,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "`And` match function evaluating incorrectly.")
 		})
 	}
@@ -337,7 +337,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "Nested match functions evaluating incorrectly.")
 		})
 	}
@@ -364,7 +364,7 @@ resource "aws_ami" "example" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.matchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "Not match functions evaluating incorrectly.")
 		})
 	}
@@ -414,7 +414,7 @@ resource "aws_ami" "testing" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.matchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "precondition functions evaluating incorrectly.")
 		})
 	}
@@ -460,7 +460,7 @@ resource "aws_s3_bucket" "test-bucket" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.matchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.matchSpec, NewEmptyCustomContext())
 			assert.Equal(t, test.expected, result, "processing variable assignments incorrectly.")
 		})
 	}
@@ -528,7 +528,7 @@ resource "google_compute_instance" "default" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			block := ParseFromSource(test.source)[0].GetBlocks()[0]
-			result := evalMatchSpec(block, &test.predicateMatchSpec, NewCustomCheckContext(nil))
+			result := evalMatchSpec(block, &test.predicateMatchSpec, NewEmptyCustomContext())
 			assert.Equal(t, result, test.expected, "`regexMatches` match function evaluating incorrectly.")
 		})
 	}


### PR DESCRIPTION
- take "name" value and store in map with index "assignVariable" value
- e.g. you can check that an attribute exists, and assign the attribute value to a variable
- variables must start with "TFSEC_VAR_"
- the variable can then be used in any following matchSpec "value" attributes
- added the above to the custom check docs

solves #1337 