### PR TITLE
Add adapter for Digital Ocean Kubernetes

### DIFF
--- a/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
+++ b/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
@@ -8,9 +8,10 @@ import (
 
 func Adapt(modules []block.Module) compute.Compute {
 	return compute.Compute{
-		Droplets:      adaptDroplets(modules),
-		Firewalls:     adaptFirewalls(modules),
-		LoadBalancers: adaptLoadBalancers(modules),
+		Droplets:           adaptDroplets(modules),
+		Firewalls:          adaptFirewalls(modules),
+		LoadBalancers:      adaptLoadBalancers(modules),
+		kubernetesClusters: adaptKubernetesClusters(modules),
 	}
 }
 

--- a/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
+++ b/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
@@ -11,7 +11,7 @@ func Adapt(modules []block.Module) compute.Compute {
 		Droplets:           adaptDroplets(modules),
 		Firewalls:          adaptFirewalls(modules),
 		LoadBalancers:      adaptLoadBalancers(modules),
-		kubernetesClusters: adaptKubernetesClusters(modules),
+		KubernetesClusters: adaptKubernetesClusters(modules),
 	}
 }
 

--- a/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
+++ b/internal/app/tfsec/adapter/digitalocean/compute/adapt.go
@@ -93,3 +93,13 @@ func adaptLoadBalancers(module block.Modules) (loadBalancers []compute.LoadBalan
 
 	return loadBalancers
 }
+
+func adaptKubernetesClusters(module block.Modules) (kubernetesClusters []compute.KubernetesCluster) {
+	for _, block := range module.GetResourcesByType("digitalocean_kubernetes_cluster") {
+		kubernetesClusters = append(kubernetesClusters, compute.KubernetesCluster{
+			AutoUpgrade:  block.GetAttribute("auto_upgrade").AsBoolValueOrDefault(false, block),
+			SurgeUpgrade: block.GetAttribute("surge_upgrade").AsBoolValueOrDefault(false, block),
+		})
+	}
+	return kubernetesClusters
+}


### PR DESCRIPTION
`go mod vendor` is a bit weird to me. I tried to use `defsec == 0.3.20`, but that caused the AWS IAM adapters to break.

I'm not really sure about tests for this, and if it should be in defsec, or here. But I guess that's second to fetching the right dependencies. Keeping all of your dependencies in the repository, versus just having a file listing them (e.g., in Python) is one aspect of GoLang that's a bit peculiar to me, but I see positives of it.