### PR TITLE
fix: avoid passing filenames to pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,18 +3,18 @@
   description: TFsec is a tool to statically analyze Terraform templates to spot potential security issues.
   language: golang
   entry: tfsec
-  types: [terraform]
+  pass_filenames: false
 
 - id: tfsec-docker
   name: TFSec Docker
   description: TFsec is a tool to statically analyze Terraform templates to spot potential security issues, uses projects official docker image.
   language: docker_image
   entry: aquasec/tfsec-alpine
-  types: [terraform]
+  pass_filenames: false
 
 - id: tfsec-system
   name: TFSec system
   description: TFsec is a tool to statically analyze Terraform templates to spot potential security issues, uses systems installed tfsec.
   language: system
   entry: tfsec
-  types: [terraform]
+  pass_filenames: false


### PR DESCRIPTION
`tfsec` behavior when passing files instead of directories as CLI args is wierd.

If you pass one file, it fails:

```sh
tfsec main.tf 
The provided path is not a dir, exiting
```

However, if you pass more than one file, it works by assuming you want it to check the whole `$PWD`:

```sh
tfsec main.tf docker.tf 

  times
  ------------------------------------------
  disk i/o             571.658µs
  parsing HCL          12.362µs
  evaluating values    390.559µs
  running checks       1.789988ms

  counts
  ------------------------------------------
  files loaded         3
  blocks               10
  modules              0

  results
  ------------------------------------------
  critical             0
  high                 0
  medium               0
  low                  0
  ignored              0

No problems detected!
```

Did you notice? I passed 2 files, but it loaded 3 (because there are 3 in this directory).

pre-commit, by default, works in batches of 4 files. This means that, if there is just 1 single `.tf` file in the repo, the hook will fail. Also, if there are more than 4 files, the hook will be executed several times when there's no need.

So, summarizing, this kind of hook needs to use `pass_filenames: false` because it works per directory and not per file.

Besides, there might be some bug in the way tfsec handles multiple files as CLI arguments, but that's another story.