### PR TITLE
fix: Fix the version at build time using Tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     main: ./cmd/tfsec
     binary: tfsec
     ldflags:
-      - "-X github.com/aquasecurity/tfsec/version.Version={{.Version}} -s -w -extldflags '-fno-PIC -static'"
+      - "-X github.com/aquasecurity/tfsec/version.Version={{.Tag}} -s -w -extldflags '-fno-PIC -static'"
     env:
       - CGO_ENABLED=0
       - GOFLAGS=-mod=vendor
@@ -23,7 +23,7 @@ builds:
     main: ./cmd/tfsec-checkgen
     binary: tfsec
     ldflags:
-      - "-X github.com/aquasecurity/tfsec/version.Version={{.Version}} -s -w -extldflags '-fno-PIC -static'"
+      - "-X github.com/aquasecurity/tfsec/version.Version={{.Tag}} -s -w -extldflags '-fno-PIC -static'"
     env:
       - CGO_ENABLED=0
       - GOFLAGS=-mod=vendor


### PR DESCRIPTION
The {{.Version}} placeholder strips the v of the front seemingly at random. Use {{.Tag}} for consistency


Resolves #1429
