### PR TITLE
fix: Handle output when terraform metadata is missing from rule

### DIFF
--- a/internal/app/tfsec/cmd/output.go
+++ b/internal/app/tfsec/cmd/output.go
@@ -45,6 +45,10 @@ func outputFormat(addExtension bool, baseFilename string, format string, dir str
 			if version.Version != "" {
 				v = version.Version
 			}
+			var links []string
+			if result.Rule().Terraform != nil {
+				links = result.Rule().Terraform.Links
+			}
 			return append([]string{
 				fmt.Sprintf(
 					"https://aquasecurity.github.io/tfsec/%s/checks/%s/%s/%s/",
@@ -53,7 +57,7 @@ func outputFormat(addExtension bool, baseFilename string, format string, dir str
 					strings.ToLower(result.Rule().Service),
 					result.Rule().ShortCode,
 				),
-			}, result.Rule().Terraform.Links...)
+			}, links...)
 		}).
 		WithBaseDir(dir).
 		WithMetricsEnabled(!conciseOutput)

--- a/internal/app/tfsec/cmd/output.go
+++ b/internal/app/tfsec/cmd/output.go
@@ -34,31 +34,33 @@ func output(baseFilename string, formats []string, dir string, results []rules.R
 	return nil
 }
 
+func gatherLinks(result rules.Result) []string {
+	v := "latest"
+	if version.Version != "" {
+		v = version.Version
+	}
+	var links []string
+	if result.Rule().Terraform != nil {
+		links = result.Rule().Terraform.Links
+	}
+	return append([]string{
+		fmt.Sprintf(
+			"https://aquasecurity.github.io/tfsec/%s/checks/%s/%s/%s/",
+			v,
+			result.Rule().Provider,
+			strings.ToLower(result.Rule().Service),
+			result.Rule().ShortCode,
+		),
+	}, links...)
+}
+
 func outputFormat(addExtension bool, baseFilename string, format string, dir string, results []rules.Result) (string, error) {
 
 	formatter := formatters.New().
 		WithDebugEnabled(debug.Enabled).
 		WithColoursEnabled(!disableColours).
 		WithGroupingEnabled(!disableGrouping).
-		WithLinksFunc(func(result rules.Result) []string {
-			v := "latest"
-			if version.Version != "" {
-				v = version.Version
-			}
-			var links []string
-			if result.Rule().Terraform != nil {
-				links = result.Rule().Terraform.Links
-			}
-			return append([]string{
-				fmt.Sprintf(
-					"https://aquasecurity.github.io/tfsec/%s/checks/%s/%s/%s/",
-					v,
-					result.Rule().Provider,
-					strings.ToLower(result.Rule().Service),
-					result.Rule().ShortCode,
-				),
-			}, links...)
-		}).
+		WithLinksFunc(gatherLinks).
 		WithBaseDir(dir).
 		WithMetricsEnabled(!conciseOutput)
 


### PR DESCRIPTION
Resolves #1439 