### PR TITLE
fix: Always prefer matching a referenced block within the same module

### DIFF
--- a/internal/pkg/block/modules.go
+++ b/internal/pkg/block/modules.go
@@ -40,11 +40,17 @@ func (m Modules) GetChildResourceIDMapByType(typeLabels ...string) ResourceIDRes
 }
 
 func (m Modules) GetReferencedBlock(referringAttr *Attribute, parentBlock *Block) (*Block, error) {
+	var bestMatch *Block
 	for _, module := range m {
 		b, err := module.GetReferencedBlock(referringAttr, parentBlock)
 		if err == nil {
-			return b, nil
+			if bestMatch == nil || b.moduleBlock == parentBlock.moduleBlock {
+				bestMatch = b
+			}
 		}
+	}
+	if bestMatch != nil {
+		return bestMatch, nil
 	}
 	return nil, fmt.Errorf("block not found")
 }


### PR DESCRIPTION
Instead of matching the first referenced block to an attribute, we now check to see if a match is possible within the same module.

Resolves #1450 