### PR TITLE
fix: Match inlined comment and README.md image description

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,5 +3,6 @@ FROM alpine:3.15
 USER nobody
 # work somewhere where we can write
 COPY tfsec /usr/bin/tfsec
-# as we specified an entrypoint, this is appended as an argument (i.e., `tfsec --help`)
+# as we are not specifying an entrypoint, this is the default executed command
+# that you could override
 CMD [ "tfsec", "--help" ]


### PR DESCRIPTION
The README.md[0] define the tfsec-ci image as without `ENTRYPOINT` to
allow use to override the default command easily. It seems to me the
inlined documentation within the Dockerfile was not matching the
README.md one.

[0] https://github.com/aquasecurity/tfsec#use-with-docker

PS: Thanks for the project(s)