### PR TITLE
feat: Add json support for tfvars files

### DIFF
--- a/internal/pkg/parser/load_vars.go
+++ b/internal/pkg/parser/load_vars.go
@@ -3,11 +3,13 @@ package parser
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/aquasecurity/defsec/metrics"
 	"github.com/aquasecurity/tfsec/internal/pkg/debug"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -50,8 +52,14 @@ func loadTFVars(filename string) (map[string]cty.Value, error) {
 	hclParseTimer.Start()
 	defer hclParseTimer.Stop()
 
-	variableFile, _ := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
-	attrs, _ := variableFile.Body.JustAttributes()
+	var attrs hcl.Attributes
+	if strings.HasSuffix(filename, ".json") {
+		variableFile, _ := hcljson.Parse(src, filename)
+		attrs, _ = variableFile.Body.JustAttributes()
+	} else {
+		variableFile, _ := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+		attrs, _ = variableFile.Body.JustAttributes()
+	}
 
 	for _, attr := range attrs {
 		debug.Log("Setting '%s' from tfvars file at %s", attr.Name, filename)

--- a/internal/pkg/parser/load_vars_test.go
+++ b/internal/pkg/parser/load_vars_test.go
@@ -1,0 +1,31 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func Test_JsonVarsFile(t *testing.T) {
+
+	path := createTestFile("test.tfvars.json", `
+{
+	"variable": {
+		"foo": {
+			"default": "bar"
+		},
+		"baz": "qux"
+	},
+	"foo2": true,
+	"foo3": 3
+}
+`,
+	)
+
+	vars, _ := LoadTFVars([]string{path})
+	assert.Equal(t, "bar", vars["variable"].GetAttr("foo").GetAttr("default").AsString())
+	assert.Equal(t, "qux", vars["variable"].GetAttr("baz").AsString())
+	assert.Equal(t, true, vars["foo2"].True())
+	assert.Equal(t, true, vars["foo3"].Equals(cty.NumberIntVal(3)).True())
+}


### PR DESCRIPTION
I needed this today and saw it was not there. I saw the issue getting marked with `good first issue`, so I wanted to jump on it 😬 Also I tried to add a simple test for parsing 👀 

Related Issue:
Resolves https://github.com/aquasecurity/tfsec/issues/1440

Related terraform code is here:
https://github.com/hashicorp/terraform/blob/c5740baa772fc65dcce5cb33be4b56f181073278/internal/command/meta_vars.go#L156
```
if strings.HasSuffix(filename, ".json") {
	var hclDiags hcl.Diagnostics
	f, hclDiags = hcljson.Parse(src, filename)
	diags = diags.Append(hclDiags)
	if f == nil || f.Body == nil {
		return diags
	}
} else {
	var hclDiags hcl.Diagnostics
	f, hclDiags = hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
	diags = diags.Append(hclDiags)
	if f == nil || f.Body == nil {
		return diags
	}
}
```