### PR TITLE
fixed aws, azure, checks etc.. 404s to github.io doc sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,16 +164,16 @@ There are also checks which are provider agnostic.
 
 | Checks |
 |:---|
-|[AWS Checks](https://aquasecurity.github.io/tfsec/latest/checks/aws/home/)|
-|[Azure Checks](https://aquasecurity.github.io/tfsec/latest/checks/azure/home/)|
-|[GCP Checks](https://aquasecurity.github.io/tfsec/latest/checks/google/home/)|
-|[CloudStack Checks](https://aquasecurity.github.io/tfsec/latest/checks/cloudstack/home/)|
-|[DigitalOcean Checks](https://aquasecurity.github.io/tfsec/latest/checks/digitalocean/home/)|
-|[GitHub Checks](https://aquasecurity.github.io/tfsec/latest/checks/github/home/)|
-|[Kubernetes Checks](https://aquasecurity.github.io/tfsec/latest/checks/kubernetes/home/)|
-|[OpenStack Checks](https://aquasecurity.github.io/tfsec/latest/checks/openstack/home/)|
-|[Oracle Checks](https://aquasecurity.github.io/tfsec/latest/checks/oracle/home/)|
-|[General Checks](https://aquasecurity.github.io/tfsec/latest/checks/general/home/)|
+|[AWS Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/aws)|
+|[Azure Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/azure)|
+|[GCP Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/google)|
+|[CloudStack Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/cloudstack)|
+|[DigitalOcean Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/digitalocean)|
+|[GitHub Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/github)|
+|[Kubernetes Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/kubernetes)|
+|[OpenStack Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/openstack)|
+|[Oracle Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/oracle)|
+|[General Checks](https://github.com/aquasecurity/tfsec/tree/master/docs/checks/general)|
 
 ## Running in CI
 


### PR DESCRIPTION
all checks ref to https://aquasecurity.github.io/tfsec/xxx are now 404, to fix it:
1/ either add dir listing as in https://ongclement.com/blog/github-pages-indexing-directory-copy
or 2/ ref them to github.com instead as in my fix here 
Any fix is better than all 404s now : )