### PR TITLE
feat(rego): Add --rego-only flag to run rego policies exclusively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/Masterminds/semver v1.5.0
-	github.com/aquasecurity/defsec v0.34.0
+	github.com/aquasecurity/defsec v0.35.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/liamg/clinch v1.5.6

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/aquasecurity/defsec v0.34.0 h1:z21bRE/WAm5aBRf4NwbKYpz+UoD1b+ywTADMgAEQNq8=
-github.com/aquasecurity/defsec v0.34.0/go.mod h1:3CaD3jUYJlrdJtEbutxFDT4MXA9IBKAq6nfPvNDBJVk=
+github.com/aquasecurity/defsec v0.35.0 h1:Fv/yTcmlesXQMytF4YThxZtUIxjG+Lqz/t0k+IUD+r0=
+github.com/aquasecurity/defsec v0.35.0/go.mod h1:3CaD3jUYJlrdJtEbutxFDT4MXA9IBKAq6nfPvNDBJVk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/internal/app/tfsec/cmd/flags.go
+++ b/internal/app/tfsec/cmd/flags.go
@@ -51,6 +51,7 @@ var disableIgnores bool
 var regoPolicyDir string
 var printRegoInput bool
 var noModuleDownloads bool
+var regoOnly bool
 
 func configureFlags(cmd *cobra.Command) {
 
@@ -86,6 +87,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&regoPolicyDir, "rego-policy-dir", "", "Directory to load rego policies from (recursively).")
 	cmd.Flags().BoolVar(&printRegoInput, "print-rego-input", false, "Print a JSON representation of the input supplied to rego policies.")
 	cmd.Flags().BoolVar(&noModuleDownloads, "no-module-downloads", false, "Do not download remote modules.")
+	cmd.Flags().BoolVar(&regoOnly, "rego-only", false, "Run rego policies exclusively.")
 
 	_ = cmd.Flags().MarkHidden("allow-checks-to-panic")
 }
@@ -153,6 +155,7 @@ func configureOptions(cmd *cobra.Command, fsRoot, dir string) ([]scanner.Option,
 		scanner.OptionWithAlternativeIDProvider(legacy.FindIDs),
 		scanner.OptionWithPolicyNamespaces("custom"),
 		scanner.OptionWithDownloads(!noModuleDownloads),
+		scanner.OptionWithRegoOnly(regoOnly),
 	)
 
 	if len(excludePaths) > 0 {

--- a/test/flags_test.go
+++ b/test/flags_test.go
@@ -461,3 +461,12 @@ func Test_Flag_NoModuleDownloads(t *testing.T) {
 	assert.Len(t, results, 0, out)
 	assert.Equal(t, 0, exit)
 }
+
+func Test_Flag_RegoOnly(t *testing.T) {
+	out, err, exit := runWithArgs("./testdata/rego/tf", "--rego-policy-dir", "./testdata/rego/policies", "--rego-only")
+	assert.Equal(t, "", err)
+	results := parseLovely(t, out)
+	assertResultsContain(t, results, "custom.rego.rego.sauce")
+	assert.Len(t, results, 1)
+	assert.Equal(t, 1, exit)
+}


### PR DESCRIPTION
Resolves #1642

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>