### PR TITLE
Use arn instead of key_id in the good example of aws-ecr-repository-customer-key

### DIFF
--- a/docs/checks/aws/ecr/repository-customer-key/index.md
+++ b/docs/checks/aws/ecr/repository-customer-key/index.md
@@ -54,7 +54,7 @@ The following example will pass the aws-ecr-repository-customer-key check.
  
  	encryption_configuration {
  		encryption_type = "KMS"
- 		kms_key = aws_kms_key.ecr_kms.key_id
+ 		kms_key = aws_kms_key.ecr_kms.arn
  	}
    }
  


### PR DESCRIPTION
The good example of `aws-ecr-repository-customer-key` suggests wrongly using KMS `aws_kms_key.key_id` instead of `aws_kms_key.arn`.

From the provider documentation:

> [kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#kms_key) - (Optional) The ARN of the KMS key to use when encryption_type is KMS. If not specified, uses the default AWS managed key for ECR.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#kms_key

Actually, aws provider can accept `aws_kms_key.key_id` as `kms_key` field, but if we use `aws_kms_key.key_id`, terraform-plan always reports the diff of `kms_key` because the state of `kms_key` field is stored as the ARN format.