### PR TITLE
docs: fix branch names in sarif github action

### DIFF
--- a/docs/guides/github-actions/github-action.md
+++ b/docs/guides/github-actions/github-action.md
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: tfsec
-        uses: tfsec/tfsec-sarif-action@main
+        uses: tfsec/tfsec-sarif-action@master
         with:
           sarif_file: tfsec.sarif         
 


### PR DESCRIPTION
Branch names were backwards: `uses: actions/checkout@main` should be `@master`, whereas `uses: tfsec/tfsec-sarif-action@master` should be `@main`.

Note that the former, `actions/checkout@main` _does_ exist, it's just no longer the active branch.