### PR TITLE
GitHub Action link correction

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -44,5 +44,5 @@ This page only covers the basics of what `tfsec` can do - much more is achievabl
 
 
 [Terraform]: https://www.terraform.io
-[GitHub Action]: ../configuration/github-actions/github-action
+[GitHub Action]: ../github-actions/github-action
 [Parameters]: ../usage


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tfsec/issues/1800

Just a simple fix. Here's a gif: 

![Gif!](https://media.giphy.com/media/zcCGBRQshGdt6/giphy.gif)