### PR TITLE
fix: Fix build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:
 .PHONY: build
 build:
 	./scripts/build.sh
+	
 
 .PHONY: generate-docs
 generate-docs:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 BINARY=tfsec
 CHECK_GEN_BINARY=tfsec-checkgen
 TAG=${TRAVIS_TAG:-development}
 GO111MODULE=on
 export CGO_ENABLED=0
-export GOFLAGS=-mod=vendor
 args=(-ldflags "-X github.com/aquasecurity/tfsec/version.Version=${TAG} -s -w -extldflags '-fno-PIC -static'")
 
 mkdir -p bin/darwin
 GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${BINARY}-darwin-amd64 "${args[@]}" ./cmd/tfsec/
-GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${CHECK_GEN_BINARY}-darwin-amd64 "${args[@]}" ./cmd/tfsec-checkgen/
+GOOS=darwin GOARCH=amd64 go build -o ./bin/darwin/${CHECK_GEN_BINARY}-darwin-amd64 "${args[@]}" ./cmd/tfsec-checkgen/
 mkdir -p bin/linux
 GOOS=linux GOARCH=amd64 go build -o bin/linux/${BINARY}-linux-amd64 "${args[@]}" ./cmd/tfsec/
 GOOS=linux GOARCH=amd64 go build -o bin/linux/${CHECK_GEN_BINARY}-linux-amd64 "${args[@]}" ./cmd/tfsec-checkgen/


### PR DESCRIPTION
Resolves #1849 - run build script using `make build`

Alternatively, just use `go build `

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
