### PR TITLE
Add missing docs from recent additions to defsec

### DIFF
--- a/docs/checks/aws/cloudtrail/ensure-cloudwatch-integration/index.md
+++ b/docs/checks/aws/cloudtrail/ensure-cloudwatch-integration/index.md
@@ -1,0 +1,84 @@
+---
+title: CloudTrail logs should be stored in S3 and also sent to CloudWatch Logs
+---
+
+# CloudTrail logs should be stored in S3 and also sent to CloudWatch Logs
+
+### Default Severity: <span class="severity low">low</span>
+
+### Explanation
+
+
+CloudTrail is a web service that records AWS API calls made in a given account. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service.
+
+CloudTrail uses Amazon S3 for log file storage and delivery, so log files are stored durably. In addition to capturing CloudTrail logs in a specified Amazon S3 bucket for long-term analysis, you can perform real-time analysis by configuring CloudTrail to send logs to CloudWatch Logs.
+
+For a trail that is enabled in all Regions in an account, CloudTrail sends log files from all those Regions to a CloudWatch Logs log group.
+
+
+### Possible Impact
+Realtime log analysis is not available without enabling CloudWatch logging
+
+### Suggested Resolution
+Enable logging to CloudWatch
+
+
+### Insecure Example
+
+The following example will fail the aws-cloudtrail-ensure-cloudwatch-integration check.
+```terraform
+
+resource "aws_cloudtrail" "bad_example" {
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+}
+ 
+```
+
+
+
+### Secure Example
+
+The following example will pass the aws-cloudtrail-ensure-cloudwatch-integration check.
+```terraform
+
+ resource "aws_cloudtrail" "good_example" {
+   is_multi_region_trail = true
+   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.example.arn}:*" 
+
+ 
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+ }
+
+resource "aws_cloudwatch_log_group" "example" {
+  name = "Example"
+}
+ 
+```
+
+
+
+### Links
+
+
+- [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html#send-cloudtrail-events-to-cloudwatch-logs-console](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html#send-cloudtrail-events-to-cloudwatch-logs-console){:target="_blank" rel="nofollow noreferrer noopener"}
+
+
+

--- a/docs/checks/aws/cloudtrail/index.md
+++ b/docs/checks/aws/cloudtrail/index.md
@@ -13,5 +13,11 @@ title: cloudtrail
 
 - [enable-log-validation](enable-log-validation) Cloudtrail log validation should be enabled to prevent tampering of log data
 
+- [ensure-cloudwatch-integration](ensure-cloudwatch-integration) CloudTrail logs should be stored in S3 and also sent to CloudWatch Logs
+
+- [no-public-log-access](no-public-log-access) The S3 Bucket backing Cloudtrail should be private
+
+- [require-bucket-access-logging](require-bucket-access-logging) You should enable bucket access logging on the CloudTrail S3 bucket.
+
 
 

--- a/docs/checks/aws/cloudtrail/no-public-log-access/index.md
+++ b/docs/checks/aws/cloudtrail/no-public-log-access/index.md
@@ -1,0 +1,86 @@
+---
+title: The S3 Bucket backing Cloudtrail should be private
+---
+
+# The S3 Bucket backing Cloudtrail should be private
+
+### Default Severity: <span class="severity critical">critical</span>
+
+### Explanation
+
+
+CloudTrail logs a record of every API call made in your account. These log files are stored in an S3 bucket. CIS recommends that the S3 bucket policy, or access control list (ACL), applied to the S3 bucket that CloudTrail logs to prevents public access to the CloudTrail logs. Allowing public access to CloudTrail log content might aid an adversary in identifying weaknesses in the affected account's use or configuration.
+
+
+### Possible Impact
+CloudTrail logs will be publicly exposed, potentially containing sensitive information
+
+### Suggested Resolution
+Restrict public access to the S3 bucket
+
+
+### Insecure Example
+
+The following example will fail the aws-cloudtrail-no-public-log-access check.
+```terraform
+
+resource "aws_cloudtrail" "bad_example" {
+   s3_bucket_name = "abcdefgh"
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+}
+
+resource "aws_s3_bucket" "good_example" {
+	bucket = "abcdefgh"
+	acl = "public-read"
+}
+ 
+```
+
+
+
+### Secure Example
+
+The following example will pass the aws-cloudtrail-no-public-log-access check.
+```terraform
+
+ resource "aws_cloudtrail" "good_example" {
+   is_multi_region_trail = true
+   s3_bucket_name = "abcdefgh"
+ 
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+ }
+
+resource "aws_s3_bucket" "good_example" {
+	bucket = "abcdefgh"
+	acl = "private"
+}
+ 
+```
+
+
+
+### Links
+
+
+- [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#is_multi_region_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#is_multi_region_trail){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.aws.amazon.com/AmazonS3/latest/userguide/configuring-block-public-access-bucket.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configuring-block-public-access-bucket.html){:target="_blank" rel="nofollow noreferrer noopener"}
+
+
+

--- a/docs/checks/aws/cloudtrail/require-bucket-access-logging/index.md
+++ b/docs/checks/aws/cloudtrail/require-bucket-access-logging/index.md
@@ -1,0 +1,91 @@
+---
+title: You should enable bucket access logging on the CloudTrail S3 bucket.
+---
+
+# You should enable bucket access logging on the CloudTrail S3 bucket.
+
+### Default Severity: <span class="severity low">low</span>
+
+### Explanation
+
+Amazon S3 bucket access logging generates a log that contains access records for each request made to your S3 bucket. An access log record contains details about the request, such as the request type, the resources specified in the request worked, and the time and date the request was processed.
+
+CIS recommends that you enable bucket access logging on the CloudTrail S3 bucket.
+
+By enabling S3 bucket logging on target S3 buckets, you can capture all events that might affect objects in a target bucket. Configuring logs to be placed in a separate bucket enables access to log information, which can be useful in security and incident response workflows.
+
+
+### Possible Impact
+There is no way to determine the access to this bucket
+
+### Suggested Resolution
+Enable access logging on the bucket
+
+
+### Insecure Example
+
+The following example will fail the aws-cloudtrail-require-bucket-access-logging check.
+```terraform
+
+resource "aws_cloudtrail" "bad_example" {
+   s3_bucket_name = "abcdefgh"
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+}
+
+resource "aws_s3_bucket" "good_example" {
+	bucket = "abcdefgh"
+	
+}
+ 
+```
+
+
+
+### Secure Example
+
+The following example will pass the aws-cloudtrail-require-bucket-access-logging check.
+```terraform
+
+ resource "aws_cloudtrail" "good_example" {
+   is_multi_region_trail = true
+   s3_bucket_name = "abcdefgh"
+ 
+   event_selector {
+     read_write_type           = "All"
+     include_management_events = true
+ 
+     data_resource {
+       type = "AWS::S3::Object"
+       values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
+     }
+   }
+ }
+
+resource "aws_s3_bucket" "good_example" {
+	bucket = "abcdefgh"
+	logging {
+		target_bucket = "target-bucket"
+	}
+}
+ 
+```
+
+
+
+### Links
+
+
+- [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#is_multi_region_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#is_multi_region_trail){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html){:target="_blank" rel="nofollow noreferrer noopener"}
+
+
+

--- a/docs/checks/aws/ec2/index.md
+++ b/docs/checks/aws/ec2/index.md
@@ -33,6 +33,8 @@ title: ec2
 
 - [no-public-ip](no-public-ip) Launch configuration should not have a public IP address.
 
+- [no-public-ip-subnet](no-public-ip-subnet) Instances in a subnet should not receive a public IP address by default.
+
 - [no-secrets-in-launch-template-user-data](no-secrets-in-launch-template-user-data) User data for EC2 instances must not contain sensitive AWS keys
 
 - [no-secrets-in-user-data](no-secrets-in-user-data) User data for EC2 instances must not contain sensitive AWS keys

--- a/docs/checks/aws/ec2/no-public-ip-subnet/index.md
+++ b/docs/checks/aws/ec2/no-public-ip-subnet/index.md
@@ -1,0 +1,56 @@
+---
+title: Instances in a subnet should not receive a public IP address by default.
+---
+
+# Instances in a subnet should not receive a public IP address by default.
+
+### Default Severity: <span class="severity high">high</span>
+
+### Explanation
+
+You should limit the provision of public IP addresses for resources. Resources should not be exposed on the public internet, but should have access limited to consumers required for the function of your application.
+
+### Possible Impact
+The instance is publicly accessible
+
+### Suggested Resolution
+Set the instance to not be publicly accessible
+
+
+### Insecure Example
+
+The following example will fail the aws-ec2-no-public-ip-subnet check.
+```terraform
+
+ resource "aws_subnet" "bad_example" {
+	vpc_id                  = "vpc-123456"
+	map_public_ip_on_launch = true
+ }
+ 
+```
+
+
+
+### Secure Example
+
+The following example will pass the aws-ec2-no-public-ip-subnet check.
+```terraform
+
+ resource "aws_subnet" "good_example" {
+	vpc_id                  = "vpc-123456"
+	map_public_ip_on_launch = false
+ }
+ 
+```
+
+
+
+### Links
+
+
+- [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses){:target="_blank" rel="nofollow noreferrer noopener"}
+
+
+

--- a/docs/checks/azure/storage/queue-services-logging-enabled/index.md
+++ b/docs/checks/azure/storage/queue-services-logging-enabled/index.md
@@ -35,6 +35,11 @@ The following example will fail the azure-storage-queue-services-logging-enabled
      queue_properties  {
    }
  }
+
+  resource "azurerm_storage_queue" "bad_example" {
+	 name                 = "my-queue"
+	 storage_account_name  = azurerm_storage_account.bad_example.name
+  }
  
 ```
 

--- a/docs/checks/github/branch_protections/index.md
+++ b/docs/checks/github/branch_protections/index.md
@@ -1,0 +1,13 @@
+---
+title: branch_protections
+---
+
+# branch_protections
+
+## Checks
+
+
+- [require_signed_commits](require_signed_commits) GitHub branch protection does not require signed commits.
+
+
+

--- a/docs/checks/github/branch_protections/require_signed_commits/index.md
+++ b/docs/checks/github/branch_protections/require_signed_commits/index.md
@@ -1,0 +1,66 @@
+---
+title: GitHub branch protection does not require signed commits.
+---
+
+# GitHub branch protection does not require signed commits.
+
+### Default Severity: <span class="severity high">high</span>
+
+### Explanation
+
+GitHub branch protection should be set to require signed commits.
+
+You can do this by setting the <code>require_signed_commits</code> attribute to 'true'.
+
+### Possible Impact
+Commits may not be verified and signed as coming from a trusted developer
+
+### Suggested Resolution
+Require signed commits
+
+
+### Insecure Example
+
+The following example will fail the github-branch_protections-require_signed_commits check.
+```terraform
+
+ resource "github_branch_protection" "good_example" {
+   repository_id = "example"
+   pattern       = "main"
+
+   require_signed_commits = false
+ }
+ 
+```
+
+
+
+### Secure Example
+
+The following example will pass the github-branch_protections-require_signed_commits check.
+```terraform
+
+ resource "github_branch_protection" "good_example" {
+   repository_id = "example"
+   pattern       = "main"
+
+   require_signed_commits = true
+ }
+ 
+```
+
+
+
+### Links
+
+
+- [https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection#require_signed_commits](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection#require_signed_commits){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification){:target="_blank" rel="nofollow noreferrer noopener"}
+
+- [https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-signed-commits](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-signed-commits){:target="_blank" rel="nofollow noreferrer noopener"}
+
+
+

--- a/docs/checks/github/index.md
+++ b/docs/checks/github/index.md
@@ -9,6 +9,8 @@ title: github
 
 - [actions](actions)
 
+- [branch_protections](branch_protections)
+
 - [repositories](repositories)
 
 

--- a/docs/checks/google/iam/index.md
+++ b/docs/checks/google/iam/index.md
@@ -1,13 +1,27 @@
 ---
-title: IAM
+title: iam
 ---
 
-# IAM
+# iam
 
 ## Checks
 
 
-- [no-folder-level-service-account-impersonation](no-folder-level-service-account-impersonation) Users should not be granted service account access at the folder level
+- [no-default-network](no-default-network) Default network should not be created at project level
+
+- [no-folder-level-default-service-account-assignment](no-folder-level-default-service-account-assignment) Roles should not be assigned to default service accounts
+
+- [no-org-level-default-service-account-assignment](no-org-level-default-service-account-assignment) Roles should not be assigned to default service accounts
+
+- [no-org-level-service-account-impersonation](no-org-level-service-account-impersonation) Users should not be granted service account access at the organization level
+
+- [no-privileged-service-accounts](no-privileged-service-accounts) Service accounts should not have roles assigned with excessive privileges
+
+- [no-project-level-default-service-account-assignment](no-project-level-default-service-account-assignment) Roles should not be assigned to default service accounts
+
+- [no-project-level-service-account-impersonation](no-project-level-service-account-impersonation) Users should not be granted service account access at the project level
+
+- [no-user-granted-permissions](no-user-granted-permissions) IAM granted directly to user.
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,9 @@ nav:
       - enable-all-regions: checks/aws/cloudtrail/enable-all-regions/index.md
       - enable-at-rest-encryption: checks/aws/cloudtrail/enable-at-rest-encryption/index.md
       - enable-log-validation: checks/aws/cloudtrail/enable-log-validation/index.md
+      - ensure-cloudwatch-integration: checks/aws/cloudtrail/ensure-cloudwatch-integration/index.md
+      - no-public-log-access: checks/aws/cloudtrail/no-public-log-access/index.md
+      - require-bucket-access-logging: checks/aws/cloudtrail/require-bucket-access-logging/index.md
     - cloudwatch:
       - log-group-customer-key: checks/aws/cloudwatch/log-group-customer-key/index.md
     - codebuild:
@@ -96,6 +99,7 @@ nav:
       - no-public-ingress-acl: checks/aws/ec2/no-public-ingress-acl/index.md
       - no-public-ingress-sgr: checks/aws/ec2/no-public-ingress-sgr/index.md
       - no-public-ip: checks/aws/ec2/no-public-ip/index.md
+      - no-public-ip-subnet: checks/aws/ec2/no-public-ip-subnet/index.md
       - no-secrets-in-launch-template-user-data: checks/aws/ec2/no-secrets-in-launch-template-user-data/index.md
       - no-secrets-in-user-data: checks/aws/ec2/no-secrets-in-user-data/index.md
       - no-sensitive-info: checks/aws/ec2/no-sensitive-info/index.md
@@ -300,6 +304,8 @@ nav:
   - github:
     - actions:
       - no-plain-text-action-secrets: checks/github/actions/no-plain-text-action-secrets/index.md
+    - branch_protections:
+      - require_signed_commits: checks/github/branch_protections/require_signed_commits/index.md
     - github: checks/github/home.md
     - repositories:
       - enable_vulnerability_alerts: checks/github/repositories/enable_vulnerability_alerts/index.md


### PR DESCRIPTION
- ensure-cloudwatch-integration: checks/aws/cloudtrail/ensure-cloudwatch-integration
- no-public-log-access: checks/aws/cloudtrail/no-public-log-access
- require-bucket-access-logging: checks/aws/cloudtrail/require-bucket-access-logging
- no-public-ip-subnet: checks/aws/ec2/no-public-ip-subnet
- require_signed_commits: checks/github/branch_protections/require_signed_commits

Fixes https://github.com/aquasecurity/tfsec/issues/1881