### PR TITLE
Set github stale bot message "days" to its config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,8 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
+    # Runs at 15:00 UTC every day.
+    # Actions schedules run at most every 5 minutes.
     - cron: '0 15 * * *'
 permissions:
   issues: write
@@ -12,10 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 365 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 365 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 365 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 365 days with no activity.'
           days-before-issue-stale: 30
           days-before-pr-stale: 30
           days-before-issue-close: 365


### PR DESCRIPTION
## what
- Set github stale bot message "days" to its config

## why
- It's confusing when the message says that the stale bot will close the issue/pr in X number of days and that X number of days is not the same as the days configured in the bot itself. This change should set the numbers to be the same.

## references
- https://github.com/aquasecurity/tfsec/issues/1943