### PR TITLE
fix typo of drop-invalid-headers doc

### DIFF
--- a/docs/checks/aws/elb/drop-invalid-headers/index.md
+++ b/docs/checks/aws/elb/drop-invalid-headers/index.md
@@ -10,7 +10,7 @@ title: Load balancers should drop invalid headers
 
 Passing unknown or invalid headers through to the target poses a potential risk of compromise. 
 
-By setting drop_invalid_header_fields to true, anything that doe not conform to well known, defined headers will be removed by the load balancer.
+By setting drop_invalid_header_fields to true, anything that does not conform to well known, defined headers will be removed by the load balancer.
 
 ### Possible Impact
 Invalid headers being passed through to the target of the load balance may exploit vulnerabilities


### PR DESCRIPTION
This PR only fix typo:pray: