### PR TITLE
Add missing legacy code AWS097

### DIFF
--- a/internal/pkg/legacy/map.go
+++ b/internal/pkg/legacy/map.go
@@ -58,6 +58,7 @@ var IDs = map[string]string{
 	"AWS083": "aws-elb-drop-invalid-headers",
 	"AWS004": "aws-elb-http-not-used",
 	"AWS010": "aws-elb-use-secure-tls-policy",
+	"AWS097": "aws-iam-block-kms-policy-wildcard",
 	"AWS037": "aws-iam-no-password-reuse",
 	"AWS099": "aws-iam-no-policy-wildcards",
 	"AWS042": "aws-iam-require-lowercase-in-passwords",


### PR DESCRIPTION
We found this code `AWS097` in an exclusion list which we are migrating to the new string based id codes.
In the legacy map I was able to find all of the codes apart from this one which seems to be missing.

Researching this (as most of the docs related to this legacy code are gone from the web), I believe I have found the corresponding new style ID: 

* https://aquasecurity.github.io/tfsec/v0.63.1/checks/aws/iam/block-kms-policy-wildcard/