### PR TITLE
Print the transition message as standard error

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -22,7 +22,7 @@ https://github.com/aquasecurity/tfsec/discussions/1994
 `
 
 func main() {
-	fmt.Print(transitionMsg)
+	fmt.Fprint(os.Stderr, transitionMsg)
 	if err := cmd.Root().Execute(); err != nil {
 		if err.Error() != "" {
 			fmt.Printf("Error: %s\n", err)


### PR DESCRIPTION
## Motivation
The transition message disable us to parse the result of JSON format. So, it would be good to print out the message as standard error. 

I tested the change locally. I was able to parse the results with a `jq` command.

```
$ /Users/***/local/src/github/tfsec/bin/darwin/tfsec-darwin-amd64 . --format json | jq -r '.'

======================================================
tfsec is joining the Trivy family

tfsec will continue to remain available
for the time being, although our engineering
attention will be directed at Trivy going forward.

You can read more here:
https://github.com/aquasecurity/tfsec/discussions/1994
======================================================
{
  "results": []
}
```