### PR TITLE
chore: update and clean up golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,13 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.52
-          skip-cache: true
-          args: --timeout 10m --verbose
+          version: v1.63
+          args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,25 +2,23 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - cyclop
+    - durationcheck
     - errcheck
+    - errname
+    - errorlint
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
-    - bodyclose
-    - contextcheck
-    - cyclop
-    - durationcheck
-    - errname
-    - errorlint
-    - exportloopref
-    - goimports
-    - gosec
-    - gocritic
 
 linters-settings: 
   cyclop:
@@ -28,9 +26,16 @@ linters-settings:
   gocritic:
     disabled-checks:
       - singleCaseSwitch
+  gosec:
+    excludes:
+      - G115
+      - G306
 
 issues:
   exclude-rules:
     - path: "."
       linters:
         - typecheck
+
+run:
+  timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ typos:
 
 .PHONY: quality
 quality:
-	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 	golangci-lint run
 
 .PHONY: fix-typos


### PR DESCRIPTION
#### Description 

This updates golangci-lint to v1.63.4 and clean up it’s configuration 