### PR TITLE
fix: Update argument name in azure storage enforce-https

### DIFF
--- a/docs/checks/azure/storage/enforce-https/index.md
+++ b/docs/checks/azure/storage/enforce-https/index.md
@@ -27,12 +27,12 @@ The following example will fail the azure-storage-enforce-https check.
 ```terraform
 
  resource "azurerm_storage_account" "bad_example" {
-   name                      = "storageaccountname"
-   resource_group_name       = azurerm_resource_group.example.name
-   location                  = azurerm_resource_group.example.location
-   account_tier              = "Standard"
-   account_replication_type  = "GRS"
-   enable_https_traffic_only = false
+   name                       = "storageaccountname"
+   resource_group_name        = azurerm_resource_group.example.name
+   location                   = azurerm_resource_group.example.location
+   account_tier               = "Standard"
+   account_replication_type   = "GRS"
+   https_traffic_only_enabled = false
  }
  
 ```
@@ -45,12 +45,12 @@ The following example will pass the azure-storage-enforce-https check.
 ```terraform
 
  resource "azurerm_storage_account" "good_example" {
-   name                      = "storageaccountname"
-   resource_group_name       = azurerm_resource_group.example.name
-   location                  = azurerm_resource_group.example.location
-   account_tier              = "Standard"
-   account_replication_type  = "GRS"
-   enable_https_traffic_only = true
+   name                       = "storageaccountname"
+   resource_group_name        = azurerm_resource_group.example.name
+   location                   = azurerm_resource_group.example.location
+   account_tier               = "Standard"
+   account_replication_type   = "GRS"
+   https_traffic_only_enabled = true
  }
  
 ```


### PR DESCRIPTION
Update argument name to 'https_traffic_only_enabled'

Reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#https_traffic_only_enabled-1