### PR TITLE
updated outdated example in azure-container-limit-authorized-ips check documentation.

### DIFF
--- a/docs/checks/azure/container/limit-authorized-ips/index.md
+++ b/docs/checks/azure/container/limit-authorized-ips/index.md
@@ -11,46 +11,39 @@ title: Ensure AKS has an API Server Authorized IP Ranges enabled
 The API server is the central way to interact with and manage a cluster. To improve cluster security and minimize attacks, the API server should only be accessible from a limited set of IP address ranges.
 
 ### Possible Impact
+
 Any IP can interact with the API server
 
 ### Suggested Resolution
-Limit the access to the API server to a limited IP range
 
+Limit the access to the API server to a limited IP range by configuring the `authorized_ip_ranges` inside the `api_server_access_profile` block.
 
 ### Insecure Example
 
 The following example will fail the azure-container-limit-authorized-ips check.
+
 ```terraform
+resource "azurerm_kubernetes_cluster" "bad_example" {
 
- resource "azurerm_kubernetes_cluster" "bad_example" {
- 
- }
- 
+}
 ```
-
-
 
 ### Secure Example
 
 The following example will pass the azure-container-limit-authorized-ips check.
+
 ```terraform
-
- resource "azurerm_kubernetes_cluster" "good_example" {
-     api_server_authorized_ip_ranges = [
- 		"1.2.3.4/32"
- 	]
- }
- 
+resource "azurerm_kubernetes_cluster" "good_example" {
+  api_server_access_profile {
+    authorized_ip_ranges = [
+      "1.2.3.4/32"
+    ]
+  }
+}
 ```
-
-
 
 ### Links
 
+- [https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#authorized_ip_ranges-1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#authorized_ip_ranges-1){:target="_blank" rel="nofollow noreferrer noopener"}
 
-- [https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#api_server_authorized_ip_ranges](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#api_server_authorized_ip_ranges){:target="_blank" rel="nofollow noreferrer noopener"}
-
-- [https://docs.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges](https://docs.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges){:target="_blank" rel="nofollow noreferrer noopener"}
-
-
-
+- [https://learn.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges](https://learn.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges){:target="_blank" rel="nofollow noreferrer noopener"}


### PR DESCRIPTION
This update fixes an outdated example in the azure-container-limit-authorized-ips check documentation.

The previous version referenced the api_server_authorized_ip_ranges argument directly in the azurerm_kubernetes_cluster resource. However, in the current AzureRM provider, this configuration has been moved under the api_server_access_profile block as authorized_ip_ranges.

This change aligns the documentation with the latest provider schema and official Terraform documentation, ensuring users follow the correct and supported configuration.

No functional changes were made to the rule itself — only the documentation and examples were updated.