### PR TITLE
fix: split CLI excludes when merging config rules

### DIFF
--- a/internal/app/tfsec/cmd/flags.go
+++ b/internal/app/tfsec/cmd/flags.go
@@ -311,10 +311,10 @@ func applyConfigFiles(options []options.ScannerOption, dir string) ([]options.Sc
 				options = append(options, scanner.ScannerWithIncludedRules(conf.IncludedChecks))
 			}
 			if len(conf.GetValidExcludedChecks()) > 0 {
-				options = append(options, scanner.ScannerWithExcludedRules(append(conf.GetValidExcludedChecks(), excludedRuleIDs)))
+				options = append(options, scanner.ScannerWithExcludedRules(append(conf.GetValidExcludedChecks(), splitRuleIDs(excludedRuleIDs)...)))
 			}
 			if len(conf.ExcludeIgnores) > 0 {
-				options = append(options, scanner.ScannerWithExcludeIgnores(append(conf.ExcludeIgnores, excludeIgnoresIDs)))
+				options = append(options, scanner.ScannerWithExcludeIgnores(append(conf.ExcludeIgnores, splitRuleIDs(excludeIgnoresIDs)...)))
 			}
 		} else {
 			logger.Log("Failed to load config file: %s", err)
@@ -322,6 +322,13 @@ func applyConfigFiles(options []options.ScannerOption, dir string) ([]options.Sc
 	}
 
 	return configureCustomChecks(options, dir)
+}
+
+func splitRuleIDs(ruleIDs string) []string {
+	if ruleIDs == "" {
+		return nil
+	}
+	return strings.Split(ruleIDs, ",")
 }
 
 func configureCustomChecks(options []options.ScannerOption, dir string) ([]options.ScannerOption, error) {

--- a/test/flags_test.go
+++ b/test/flags_test.go
@@ -330,6 +330,20 @@ func Test_Flag_ConfigFile(t *testing.T) {
 	assert.Equal(t, 1, exit)
 }
 
+func Test_Flag_ConfigFile_WithMultipleCliExcludes(t *testing.T) {
+	out, err, exit := runWithArgs(
+		"./testdata/fail",
+		"--config-file", "./testdata/config/config.yml",
+		"--exclude", "aws-s3-block-public-acls,aws-s3-block-public-policy",
+	)
+	results := parseLovely(t, out)
+	assertResultsNotContain(t, results, "aws-s3-enable-versioning")
+	assertResultsNotContain(t, results, "aws-s3-block-public-acls")
+	assertResultsNotContain(t, results, "aws-s3-block-public-policy")
+	assert.Equal(t, "", err)
+	assert.Equal(t, 1, exit)
+}
+
 func Test_Flag_Debug(t *testing.T) {
 	// use json to ensure all debug goes to stderr and does not break json format
 	for _, flag := range []string{"--debug", "--verbose"} {


### PR DESCRIPTION
Small fix for a weird config + CLI footgun.

Repro:
  go run ./cmd/tfsec ./test/testdata/fail --config-file ./test/testdata/config/config.yml --exclude aws-s3-block-public-acls,aws-s3-block-public-policy --format json

Before this, both CLI-excluded S3 rules still showed up when a config file also had excludes. The comma list got merged as one big id, lol.

Now the CLI list is split before merging, same as the normal flag path. Added a regression test too.

Checked:
  go test ./...

Related old context: #532, #1839, #1897